### PR TITLE
feat(bundle): ENTESB-15469 - upgrade CRD api version from v1beta to v1 to support default values in schema

### DIFF
--- a/bundle/manifests/hawt.io_hawtios.yaml
+++ b/bundle/manifests/hawt.io_hawtios.yaml
@@ -1,25 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hawtios.hawt.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .metadata.creationTimestamp
-    description: Creation phase
-    name: Age
-    type: date
-  - JSONPath: .status.image
-    description: Console image
-    name: Image
-    type: string
-  - JSONPath: .status.phase
-    description: Console phase
-    name: Phase
-    type: string
-  - JSONPath: .status.URL
-    description: Console URL
-    name: URL
-    type: string
   group: hawt.io
   names:
     categories:
@@ -28,189 +11,206 @@ spec:
     listKind: HawtioList
     plural: hawtios
     singular: hawtio
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Hawtio Console
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Defines the desired state of Hawtio
-          properties:
-            auth:
-              description: The authentication configuration
-              properties:
-                clientCertCommonName:
-                  description: The generated client certificate CN
-                  type: string
-                clientCertExpirationDate:
-                  description: The generated client certificate expiration date
-                  format: date-time
-                  type: string
-              type: object
-            config:
-              description: The Hawtio console configuration
-              properties:
-                about:
-                  description: The information to be displayed in the About page
-                  properties:
-                    additionalInfo:
-                      description: The text for the description section
-                      type: string
-                    copyright:
-                      description: The text for the copyright section
-                      type: string
-                    imgSrc:
-                      description: The image displayed in the page. It can be a path, relative to the Hawtio status URL, or an absolute URL.
-                      type: string
-                    productInfo:
-                      description: List of product information
-                      items:
-                        description: The product information displayed in the About page
-                        properties:
-                          name:
-                            description: The name of the product information
-                            type: string
-                          value:
-                            description: The value of the product information
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    title:
-                      description: The title of the page
-                      type: string
-                  type: object
-                branding:
-                  description: The UI branding
-                  properties:
-                    appLogoUrl:
-                      description: The URL of the logo, that displays in the navigation bar. It can be a path, relative to the Hawtio status URL, or an absolute URL.
-                      type: string
-                    appName:
-                      description: The application title, that usually displays in the Web browser tab.
-                      type: string
-                    css:
-                      description: The URL of an external CSS stylesheet, that can be used to style the application. It can be a path, relative to the Hawtio status URL, or an absolute URL.
-                      type: string
-                    favicon:
-                      description: The URL of the favicon, that usually displays in the Web browser tab. It can be a path, relative to the Hawtio status URL, or an absolute URL.
-                      type: string
-                  type: object
-                disabledRoutes:
-                  description: Disables UI components with matching routes
-                  items:
-                    type: string
-                  type: array
-                online:
-                  description: The OpenShift related configuration
-                  properties:
-                    consoleLink:
-                      description: The configuration for the OpenShift Web console link. A link is added to the application menu when the Hawtio deployment is equal to 'cluster'. Otherwise, a link is added to the Hawtio project dashboard.
-                      properties:
-                        imageRelativePath:
-                          description: The path, relative to the Hawtio status URL, for the icon used in front of the link in the application menu. It is only applicable when the Hawtio deployment type is equal to 'cluster'. The image should be square and will be shown at 24x24 pixels.
-                          type: string
-                        section:
-                          description: The section of the application menu in which the link should appear. It is only applicable when the Hawtio deployment type is equal to 'cluster'.
-                          type: string
-                        text:
-                          description: The text display for the link
-                          type: string
-                      type: object
-                    projectSelector:
-                      description: The selector used to watch for projects. It is only applicable when the Hawtio deployment type is equal to 'cluster'. By default, all the projects the logged in user has access to are watched. The string representation of the selector must be provided, as mandated by the `--selector`, or `-l`, options from the `kubectl get` command. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-                      type: string
-                  type: object
-              type: object
-            rbac:
-              description: The RBAC configuration
-              properties:
-                configMap:
-                  description: The name of the ConfigMap that contains the ACL definition.
-                  type: string
-              type: object
-            replicas:
-              description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
-              format: int32
-              type: integer
-            resources:
-              description: The Hawtio console compute resources
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            routeHostName:
-              description: 'The edge host name of the route that exposes the Hawtio service externally. If not specified, it is automatically generated and is of the form: <name>[-<namespace>].<suffix> where <suffix> is the default routing sub-domain as configured for the cluster. Note that the operator will recreate the route if the field is emptied, so that the host is re-generated.'
-              type: string
-            type:
-              description: 'The deployment type. Defaults to cluster. cluster: Hawtio is capable of discovering and managing applications across all namespaces the authenticated user has access to. namespace: Hawtio is capable of discovering and managing applications within the deployment namespace.'
-              enum:
-              - Cluster
-              - Namespace
-              type: string
-            version:
-              description: The Hawtio console container image version. Defaults to 'latest'.
-              type: string
-          type: object
-        status:
-          description: Reports the observed state of Hawtio
-          properties:
-            URL:
-              description: The Hawtio console route URL
-              type: string
-            image:
-              description: The Hawtio console container image
-              type: string
-            phase:
-              description: The Hawtio deployment phase
-              enum:
-              - Initialized
-              - Deployed
-              - Failed
-              type: string
-            replicas:
-              description: The actual number of pods
-              format: int32
-              type: integer
-            selector:
-              description: The label selector for the Hawtio pods
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      description: Creation phase
+      name: Age
+      type: date
+    - jsonPath: .status.image
+      description: Console image
+      name: Image
+      type: string
+    - jsonPath: .status.phase
+      description: Console phase
+      name: Phase
+      type: string
+    - jsonPath: .status.URL
+      description: Console URL
+      name: URL
+      type: string
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: Hawtio Console
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Defines the desired state of Hawtio
+            properties:
+              auth:
+                description: The authentication configuration
+                properties:
+                  clientCertCommonName:
+                    description: The generated client certificate CN
+                    type: string
+                  clientCertExpirationDate:
+                    description: The generated client certificate expiration date
+                    format: date-time
+                    type: string
+                type: object
+              config:
+                description: The Hawtio console configuration
+                properties:
+                  about:
+                    description: The information to be displayed in the About page
+                    properties:
+                      additionalInfo:
+                        description: The text for the description section
+                        type: string
+                      copyright:
+                        description: The text for the copyright section
+                        type: string
+                      imgSrc:
+                        description: The image displayed in the page. It can be a path, relative to the Hawtio status URL, or an absolute URL.
+                        type: string
+                      productInfo:
+                        description: List of product information
+                        items:
+                          description: The product information displayed in the About page
+                          properties:
+                            name:
+                              description: The name of the product information
+                              type: string
+                            value:
+                              description: The value of the product information
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      title:
+                        description: The title of the page
+                        type: string
+                    type: object
+                  branding:
+                    description: The UI branding
+                    properties:
+                      appLogoUrl:
+                        description: The URL of the logo, that displays in the navigation bar. It can be a path, relative to the Hawtio status URL, or an absolute URL.
+                        type: string
+                      appName:
+                        description: The application title, that usually displays in the Web browser tab.
+                        type: string
+                      css:
+                        description: The URL of an external CSS stylesheet, that can be used to style the application. It can be a path, relative to the Hawtio status URL, or an absolute URL.
+                        type: string
+                      favicon:
+                        description: The URL of the favicon, that usually displays in the Web browser tab. It can be a path, relative to the Hawtio status URL, or an absolute URL.
+                        type: string
+                    type: object
+                  disabledRoutes:
+                    description: Disables UI components with matching routes
+                    items:
+                      type: string
+                    type: array
+                  online:
+                    description: The OpenShift related configuration
+                    properties:
+                      consoleLink:
+                        description: The configuration for the OpenShift Web console link. A link is added to the application menu when the Hawtio deployment is equal to 'cluster'. Otherwise, a link is added to the Hawtio project dashboard.
+                        properties:
+                          imageRelativePath:
+                            description: The path, relative to the Hawtio status URL, for the icon used in front of the link in the application menu. It is only applicable when the Hawtio deployment type is equal to 'cluster'. The image should be square and will be shown at 24x24 pixels.
+                            type: string
+                          section:
+                            description: The section of the application menu in which the link should appear. It is only applicable when the Hawtio deployment type is equal to 'cluster'.
+                            type: string
+                          text:
+                            description: The text display for the link
+                            type: string
+                        type: object
+                      projectSelector:
+                        description: The selector used to watch for projects. It is only applicable when the Hawtio deployment type is equal to 'cluster'. By default, all the projects the logged in user has access to are watched. The string representation of the selector must be provided, as mandated by the `--selector`, or `-l`, options from the `kubectl get` command. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                        type: string
+                    type: object
+                type: object
+              rbac:
+                description: The RBAC configuration
+                properties:
+                  configMap:
+                    description: The name of the ConfigMap that contains the ACL definition.
+                    type: string
+                type: object
+              replicas:
+                description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+                format: int32
+                type: integer
+              resources:
+                description: The Hawtio console compute resources
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              routeHostName:
+                description: 'The edge host name of the route that exposes the Hawtio service externally. If not specified, it is automatically generated and is of the form: <name>[-<namespace>].<suffix> where <suffix> is the default routing sub-domain as configured for the cluster. Note that the operator will recreate the route if the field is emptied, so that the host is re-generated.'
+                type: string
+              type:
+                description: 'The deployment type. Defaults to cluster. cluster: Hawtio is capable of discovering and managing applications across all namespaces the authenticated user has access to. namespace: Hawtio is capable of discovering and managing applications within the deployment namespace.'
+                enum:
+                - Cluster
+                - Namespace
+                type: string
+              version:
+                description: The Hawtio console container image version. Defaults to 'latest'.
+                type: string
+            type: object
+          status:
+            description: Reports the observed state of Hawtio
+            properties:
+              URL:
+                description: The Hawtio console route URL
+                type: string
+              image:
+                description: The Hawtio console container image
+                type: string
+              phase:
+                description: The Hawtio deployment phase
+                enum:
+                - Initialized
+                - Deployed
+                - Failed
+                type: string
+              replicas:
+                description: The actual number of pods
+                format: int32
+                type: integer
+              selector:
+                description: The label selector for the Hawtio pods
+                type: string
+            type: object
+        type: object

--- a/deploy/crd/hawtio_v1alpha1_hawtio_crd.yaml
+++ b/deploy/crd/hawtio_v1alpha1_hawtio_crd.yaml
@@ -1,25 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hawtios.hawt.io
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .metadata.creationTimestamp
-      description: Creation phase
-      name: Age
-      type: date
-    - JSONPath: .status.image
-      description: Console image
-      name: Image
-      type: string
-    - JSONPath: .status.phase
-      description: Console phase
-      name: Phase
-      type: string
-    - JSONPath: .status.URL
-      description: Console URL
-      name: URL
-      type: string
   group: hawt.io
   names:
     categories:
@@ -28,230 +11,247 @@ spec:
     listKind: HawtioList
     plural: hawtios
     singular: hawtio
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Hawtio Console
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Defines the desired state of Hawtio
-          properties:
-            auth:
-              description: The authentication configuration
-              properties:
-                clientCertCommonName:
-                  description: The generated client certificate CN
-                  type: string
-                clientCertExpirationDate:
-                  description: The generated client certificate expiration date
-                  format: date-time
-                  type: string
-              type: object
-            config:
-              description: The Hawtio console configuration
-              properties:
-                about:
-                  description: The information to be displayed in the About page
-                  properties:
-                    additionalInfo:
-                      description: The text for the description section
-                      type: string
-                    copyright:
-                      description: The text for the copyright section
-                      type: string
-                    imgSrc:
-                      description: The image displayed in the page. It can be a path,
-                        relative to the Hawtio status URL, or an absolute URL.
-                      type: string
-                    productInfo:
-                      description: List of product information
-                      items:
-                        description: The product information displayed in the About
-                          page
-                        properties:
-                          name:
-                            description: The name of the product information
-                            type: string
-                          value:
-                            description: The value of the product information
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                    title:
-                      description: The title of the page
-                      type: string
-                  type: object
-                branding:
-                  description: The UI branding
-                  properties:
-                    appLogoUrl:
-                      description: The URL of the logo, that displays in the navigation
-                        bar. It can be a path, relative to the Hawtio status URL,
-                        or an absolute URL.
-                      type: string
-                    appName:
-                      description: The application title, that usually displays in
-                        the Web browser tab.
-                      type: string
-                    css:
-                      description: The URL of an external CSS stylesheet, that can
-                        be used to style the application. It can be a path, relative
-                        to the Hawtio status URL, or an absolute URL.
-                      type: string
-                    favicon:
-                      description: The URL of the favicon, that usually displays in
-                        the Web browser tab. It can be a path, relative to the Hawtio
-                        status URL, or an absolute URL.
-                      type: string
-                  type: object
-                disabledRoutes:
-                  description: Disables UI components with matching routes
-                  items:
-                    type: string
-                  type: array
-                online:
-                  description: The OpenShift related configuration
-                  properties:
-                    consoleLink:
-                      description: The configuration for the OpenShift Web console
-                        link. A link is added to the application menu when the Hawtio
-                        deployment is equal to 'cluster'. Otherwise, a link is added
-                        to the Hawtio project dashboard.
-                      properties:
-                        imageRelativePath:
-                          description: The path, relative to the Hawtio status URL,
-                            for the icon used in front of the link in the application
-                            menu. It is only applicable when the Hawtio deployment
-                            type is equal to 'cluster'. The image should be square
-                            and will be shown at 24x24 pixels.
-                          type: string
-                        section:
-                          description: The section of the application menu in which
-                            the link should appear. It is only applicable when the
-                            Hawtio deployment type is equal to 'cluster'.
-                          type: string
-                        text:
-                          description: The text display for the link
-                          type: string
-                      type: object
-                    projectSelector:
-                      description: The selector used to watch for projects. It is
-                        only applicable when the Hawtio deployment type is equal to
-                        'cluster'. By default, all the projects the logged in user
-                        has access to are watched. The string representation of the
-                        selector must be provided, as mandated by the `--selector`,
-                        or `-l`, options from the `kubectl get` command. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-                      type: string
-                  type: object
-              type: object
-            rbac:
-              description: The RBAC configuration
-              properties:
-                configMap:
-                  description: The name of the ConfigMap that contains the ACL definition.
-                  type: string
-              type: object
-            replicas:
-              description: Number of desired pods. This is a pointer to distinguish
-                between explicit zero and not specified. Defaults to 1.
-              format: int32
-              type: integer
-            resources:
-              description: The Hawtio console compute resources
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            routeHostName:
-              description: 'The edge host name of the route that exposes the Hawtio
-                service externally. If not specified, it is automatically generated
-                and is of the form: <name>[-<namespace>].<suffix> where <suffix> is
-                the default routing sub-domain as configured for the cluster. Note
-                that the operator will recreate the route if the field is emptied,
-                so that the host is re-generated.'
-              type: string
-            type:
-              description: 'The deployment type. Defaults to cluster. cluster: Hawtio
-                is capable of discovering and managing applications across all namespaces
-                the authenticated user has access to. namespace: Hawtio is capable
-                of discovering and managing applications within the deployment namespace.'
-              enum:
-                - Cluster
-                - Namespace
-              type: string
-            version:
-              description: The Hawtio console container image version. Defaults to
-                'latest'.
-              type: string
-          type: object
-        status:
-          description: Reports the observed state of Hawtio
-          properties:
-            URL:
-              description: The Hawtio console route URL
-              type: string
-            image:
-              description: The Hawtio console container image
-              type: string
-            phase:
-              description: The Hawtio deployment phase
-              enum:
-                - Initialized
-                - Deployed
-                - Failed
-              type: string
-            replicas:
-              description: The actual number of pods
-              format: int32
-              type: integer
-            selector:
-              description: The label selector for the Hawtio pods
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
     - name: v1alpha1
       served: true
       storage: true
+      additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          description: Creation phase
+          name: Age
+          type: date
+        - jsonPath: .status.image
+          description: Console image
+          name: Image
+          type: string
+        - jsonPath: .status.phase
+          description: Console phase
+          name: Phase
+          type: string
+        - jsonPath: .status.URL
+          description: Console URL
+          name: URL
+          type: string
+      subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: Hawtio Console
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Defines the desired state of Hawtio
+              properties:
+                auth:
+                  description: The authentication configuration
+                  properties:
+                    clientCertCommonName:
+                      description: The generated client certificate CN
+                      type: string
+                    clientCertExpirationDate:
+                      description: The generated client certificate expiration date
+                      format: date-time
+                      type: string
+                  type: object
+                config:
+                  description: The Hawtio console configuration
+                  properties:
+                    about:
+                      description: The information to be displayed in the About page
+                      properties:
+                        additionalInfo:
+                          description: The text for the description section
+                          type: string
+                        copyright:
+                          description: The text for the copyright section
+                          type: string
+                        imgSrc:
+                          description: The image displayed in the page. It can be a path,
+                            relative to the Hawtio status URL, or an absolute URL.
+                          type: string
+                        productInfo:
+                          description: List of product information
+                          items:
+                            description: The product information displayed in the About
+                              page
+                            properties:
+                              name:
+                                description: The name of the product information
+                                type: string
+                              value:
+                                description: The value of the product information
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                        title:
+                          description: The title of the page
+                          type: string
+                      type: object
+                    branding:
+                      description: The UI branding
+                      properties:
+                        appLogoUrl:
+                          description: The URL of the logo, that displays in the navigation
+                            bar. It can be a path, relative to the Hawtio status URL,
+                            or an absolute URL.
+                          type: string
+                        appName:
+                          description: The application title, that usually displays in
+                            the Web browser tab.
+                          type: string
+                        css:
+                          description: The URL of an external CSS stylesheet, that can
+                            be used to style the application. It can be a path, relative
+                            to the Hawtio status URL, or an absolute URL.
+                          type: string
+                        favicon:
+                          description: The URL of the favicon, that usually displays in
+                            the Web browser tab. It can be a path, relative to the Hawtio
+                            status URL, or an absolute URL.
+                          type: string
+                      type: object
+                    disabledRoutes:
+                      description: Disables UI components with matching routes
+                      items:
+                        type: string
+                      type: array
+                    online:
+                      description: The OpenShift related configuration
+                      properties:
+                        consoleLink:
+                          description: The configuration for the OpenShift Web console
+                            link. A link is added to the application menu when the Hawtio
+                            deployment is equal to 'cluster'. Otherwise, a link is added
+                            to the Hawtio project dashboard.
+                          properties:
+                            imageRelativePath:
+                              description: The path, relative to the Hawtio status URL,
+                                for the icon used in front of the link in the application
+                                menu. It is only applicable when the Hawtio deployment
+                                type is equal to 'cluster'. The image should be square
+                                and will be shown at 24x24 pixels.
+                              type: string
+                            section:
+                              description: The section of the application menu in which
+                                the link should appear. It is only applicable when the
+                                Hawtio deployment type is equal to 'cluster'.
+                              type: string
+                            text:
+                              description: The text display for the link
+                              type: string
+                          type: object
+                        projectSelector:
+                          description: The selector used to watch for projects. It is
+                            only applicable when the Hawtio deployment type is equal to
+                            'cluster'. By default, all the projects the logged in user
+                            has access to are watched. The string representation of the
+                            selector must be provided, as mandated by the `--selector`,
+                            or `-l`, options from the `kubectl get` command. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                          type: string
+                      type: object
+                  type: object
+                rbac:
+                  description: The RBAC configuration
+                  properties:
+                    configMap:
+                      description: The name of the ConfigMap that contains the ACL definition.
+                      type: string
+                  type: object
+                replicas:
+                  description: Number of desired pods. This is a pointer to distinguish
+                    between explicit zero and not specified. Defaults to 1.
+                  format: int32
+                  type: integer
+                resources:
+                  description: The Hawtio console compute resources
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources
+                        allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute resources
+                        required. If Requests is omitted for a container, it defaults
+                        to Limits if that is explicitly specified, otherwise to an implementation-defined
+                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                routeHostName:
+                  description: 'The edge host name of the route that exposes the Hawtio
+                    service externally. If not specified, it is automatically generated
+                    and is of the form: <name>[-<namespace>].<suffix> where <suffix> is
+                    the default routing sub-domain as configured for the cluster. Note
+                    that the operator will recreate the route if the field is emptied,
+                    so that the host is re-generated.'
+                  type: string
+                type:
+                  description: 'The deployment type. Defaults to cluster. cluster: Hawtio
+                    is capable of discovering and managing applications across all namespaces
+                    the authenticated user has access to. namespace: Hawtio is capable
+                    of discovering and managing applications within the deployment namespace.'
+                  enum:
+                    - Cluster
+                    - Namespace
+                  type: string
+                version:
+                  description: The Hawtio console container image version. Defaults to
+                    'latest'.
+                  type: string
+              type: object
+            status:
+              description: Reports the observed state of Hawtio
+              properties:
+                URL:
+                  description: The Hawtio console route URL
+                  type: string
+                image:
+                  description: The Hawtio console container image
+                  type: string
+                phase:
+                  description: The Hawtio deployment phase
+                  enum:
+                    - Initialized
+                    - Deployed
+                    - Failed
+                  type: string
+                replicas:
+                  description: The actual number of pods
+                  format: int32
+                  type: integer
+                selector:
+                  description: The label selector for the Hawtio pods
+                  type: string
+              type: object
+          type: object

--- a/pkg/controller/hawtio/hawtio_controller.go
+++ b/pkg/controller/hawtio/hawtio_controller.go
@@ -16,7 +16,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +68,7 @@ func Add(mgr manager.Manager, bv util.BuildVariables) error {
 	if err != nil {
 		return err
 	}
-	err = apiextensionsv1beta1.AddToScheme(mgr.GetScheme())
+	err = apiextensionsv1.AddToScheme(mgr.GetScheme())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/hawtio/test/crd_validation_test.go
+++ b/pkg/controller/hawtio/test/crd_validation_test.go
@@ -79,7 +79,7 @@ func getSchema(t *testing.T) validation.Schema {
 	crdFile := "../../../../deploy/crd/hawtio_v1alpha1_hawtio_crd.yaml"
 	bytes, err := ioutil.ReadFile(crdFile)
 	assert.NoError(t, err, "Error reading CRD yaml %v", crdFile)
-	schema, err := validation.New(bytes)
+	schema, err := validation.NewVersioned(bytes, "v1alpha1")
 	assert.NoError(t, err)
 	return schema
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-15469

Since `apiextensions.k8s.io/v1` CRD supports default values in `openAPIV3Schema` and OpenShift web console just relies on [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form) for the operand form view (which supports the schema default values as well), I think it's good idea to bump up the version of CRD to `apiextensions.k8s.io/v1` and introduce a default value for the RBAC `enabled` property as the more permanent solution to ENTESB-15469.

@astefanutti Please review and let me know your thoughts.