### PR TITLE
ENTESB-15803: Adds standardised kustomize make rules for installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,27 @@
 ORG = hawtio
 NAMESPACE ?= hawtio
 PROJECT = operator
-TAG ?= latest
+DEFAULT_IMAGE := docker.io/hawtio/operator
+IMAGE ?= $(DEFAULT_IMAGE)
+DEFAULT_TAG := latest
+TAG ?= $(DEFAULT_TAG)
 VERSION ?= 0.3.0
+DEBUG ?= false
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
+
+INSTALL_ROOT := deploy
+GEN_SUFFIX := gen.yaml
+
+#
+# Allows for resources to be loaded from outside the root location of
+# the kustomize config file. Ensures that resource don't need to be
+# copied around the file system.
+#
+# See https://kubectl.docs.kubernetes.io/faq/kustomize
+#
+KOPTIONS := --load_restrictor LoadRestrictionsNone
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -13,6 +29,19 @@ GOBIN=$(shell go env GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif
+
+.PHONY: image build compile go-generate test manifests k8s-generate install deploy bundle controller-gen kustomize setup operator app
+
+#
+# Function for editing kustomize parameters
+# Takes single parameter representing the directory
+# containing the kustomization to be edited
+#
+define set-kvars
+	cd $(1) && \
+	$(KUSTOMIZE) edit set namespace $(NAMESPACE) && \
+	$(KUSTOMIZE) edit set image $(DEFAULT_IMAGE)=$(IMAGE):$(TAG)
+endef
 
 default: image
 
@@ -33,21 +62,33 @@ test:
 
 # Generate manifests, e.g. CRDs
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=deploy/crd
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=$(INSTALL_ROOT)/crd
 
 # Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations
 k8s-generate: controller-gen
 	$(CONTROLLER_GEN) paths="./..." object
 
+#
+# Installation of just the CRD
+# Can only be executed as a cluster-admin
+#
 install:
-	kubectl apply -f deploy/crd/hawtio_v1alpha1_hawtio_crd.yaml
+	kubectl apply -f $(INSTALL_ROOT)/crd/hawtio_v1alpha1_hawtio_crd.yaml
 
+#
+# Full deploy of all resources.
+# Can only be executed as a cluster-admin
+#
 deploy: install kustomize
-	cd deploy && $(KUSTOMIZE) edit set namespace $(NAMESPACE)
-	$(KUSTOMIZE) build deploy | kubectl apply -f -
+	$(call set-kvars,$(INSTALL_ROOT))
+ifeq ($(DEBUG), false)
+	$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT) | kubectl apply -f -
+else
+	$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)
+endif
 
 # Generate bundle manifests and metadata
-.PHONY: bundle
+
 bundle: kustomize
 	$(KUSTOMIZE) build bundle | operator-sdk generate bundle --kustomize-dir bundle --version $(VERSION)
 	#operator-sdk bundle validate ./bundle
@@ -82,4 +123,49 @@ ifeq (, $(shell which kustomize))
 KUSTOMIZE=$(GOBIN)/kustomize
 else
 KUSTOMIZE=$(shell which kustomize)
+endif
+
+#
+# Cluster-Admin install step that configures cluster roles and
+# installs the CRD. Grants a user the necessary privileges to
+# install the operator.
+#
+# Setup the installation by installing crds, roles and granting
+# privileges for the installing user.
+#
+setup: kustomize
+	#@ Must be invoked by a user with cluster-admin privileges
+	$(call set-kvars,$(INSTALL_ROOT)/setup)
+ifeq ($(DEBUG), false)
+	$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)/setup | kubectl apply -f -
+else
+	$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)/setup
+endif
+
+#
+# Install just the operator as a normal user
+# (must be granted the privileges by the Cluster-Admin
+# executed `setup` procedure)
+#
+operator: kustomize
+	#@ Can be invoked by a user with namespace privileges (rather than a cluster-admin)
+	$(call set-kvars,$(INSTALL_ROOT)/operator)
+ifeq ($(DEBUG), false)
+	$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)/operator | kubectl apply -f -
+else
+	$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)/operator
+endif
+
+#
+# Install the app CR and deploy the operator as a normal user
+# (must be granted the privileges by the Cluster-Admin
+# executed `setup` procedure)
+#
+app: operator kustomize
+	#@ Can be invoked by a user with namespace privileges (rather than a cluster-admin)
+	$(call set-kvars,$(INSTALL_ROOT)/app)
+ifeq ($(DEBUG), false)
+		$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)/app | kubectl apply -f -
+else
+		$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)/app
 endif

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,3 @@
+**/*.gen.yaml
+
+release/*-installer*

--- a/deploy/app/kustomization.yaml
+++ b/deploy/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hawtio
+
+resources:
+- ../crs/hawtio_v1alpha1_hawtio_cr.yaml

--- a/deploy/operator/kustomization.yaml
+++ b/deploy/operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hawtio
+
+resources:
+- ../service_account.yaml
+- ../operator.yaml

--- a/deploy/release/Makefile
+++ b/deploy/release/Makefile
@@ -1,0 +1,37 @@
+.PHONY: $(SUBDIRS)
+
+
+INSTALLDIR := $(RELEASE_NAME)-installer
+RELEASEDIRS := ../app ../crd ../crs ../operator ../setup
+
+default: release
+
+check-vars:
+ifndef RELEASE_VERSION
+	$(error RELEASE_VERSION is not set)
+endif
+ifndef RELEASE_NAME
+	$(error RELEASE_NAME is not set)
+endif
+
+create:
+	#@ Make a new build directory
+	mkdir -p $(INSTALLDIR)
+	#@ Copy directories into build directory
+	for dir in $(RELEASEDIRS); do \
+		cp -rf $$dir $(INSTALLDIR)/; \
+	done
+	#@ Copy root yaml files into build directory
+	cp -f ../*.yaml $(INSTALLDIR)/
+	#@ Remove any generated yaml files (need the tmpl files)
+	for f in `find $(INSTALLDIR) -name "*.gen.yaml"`; do \
+		rm -f $$f; \
+	done
+	#@ Makefile is being moved down a level, change the INSTALL ROOT and copy it
+	cat ../../Makefile | sed 's~INSTALL_ROOT := deploy~INSTALL_ROOT := .~' > $(INSTALLDIR)/Makefile
+
+release: check-vars create
+	tar zcvf $(INSTALLDIR)-$(RELEASE_VERSION).tar.gz $(INSTALLDIR)
+
+clean:
+	rm -rf *-installer *.tar.gz

--- a/deploy/setup/kustomization.yaml
+++ b/deploy/setup/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hawtio
+
+resources:
+- ../crd/hawtio_v1alpha1_hawtio_crd.yaml
+- ../cluster_role.yaml
+- ../cluster_role_binding.yaml
+- ../role.yaml
+- ../role_binding.yaml
+- ../service_account.yaml
+- role_app_user.yaml

--- a/deploy/setup/role_app_user.yaml
+++ b/deploy/setup/role_app_user.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hawtio-operator-installer
+  labels:
+    #
+    # Add these permissions to the "admin" and "edit" default roles
+    # to allow namespace admin user access hawtio api
+    #
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - "hawt.io"
+  resources:
+  - "*"
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]


### PR DESCRIPTION
* Adds additional rules that are standard across the fuse operators, ie.
  setup, operator, app

* Adds overrideable variables:
 ** IMAGE: image of the operator
 ** TAG: tag of the operator image
 ** DEBUG: views the resources to be installed rather but not applying them

* INSTALL_ROOT: var required to be overwritten when the kustomize package
  is released.

* KOPTIONS: Setting that allows for resources to be referenced by
  kustomization files that are not within the same directory root structure

* setup rule: Executed by cluster-admin that installs the roles, bindings
  and CRD. Grants privileges to named user, specified by KUBE_USER

* operator rule: Executed by user and deploy operator only

* app rule: Executed by user deploys operator and the custom resource

* role_app_user.tmpl
 * Provides the user with the privileges to access the hawt.io api
   allowing them to install the CR
 * Contains a KUBE_USER var that is replaced with the preferred value at
   install time (default is developer)

* release
 * Makefile that packages the kustomization installation config into a tar
   archive, allowing it to be released separately from the source repo