### PR TITLE
Provide possibility to add additional labels on pod template spec

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -26,6 +26,7 @@ var (
 	ProductName                          string
 	ServerRootDirectory                  string
 	CertificateCommonName                string
+	AdditionalLabels                     string
 )
 
 var log = logf.Log.WithName("cmd")
@@ -88,6 +89,7 @@ func main() {
 		ProductName:                          ProductName,
 		ServerRootDirectory:                  ServerRootDirectory,
 		ClientCertCommonName:                 CertificateCommonName,
+		AdditionalLabels:                     AdditionalLabels,
 	}
 	if err := controller.AddToManager(mgr, bv); err != nil {
 		log.Error(err, "")

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -12,4 +12,6 @@ type BuildVariables struct {
 	ServerRootDirectory string
 	// The default common name for the generated client certificates
 	ClientCertCommonName string
+	// Additional template spec labels
+	AdditionalLabels string
 }


### PR DESCRIPTION
There was a request from downstream that Hawtio console should have possibility to add additional custom labels on spec.template.metadata. 

When building Hawtio, one could specify `go build -ldflags="-X main.AdditionalLabels=type=console;version=1.0"` to add these two labels.