### PR TITLE
feat: add possibility to use user-created routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ route:
 
 If the 'key' isn't defined 'tls.crt' is automatically used.
 
+### Custom routes
+To use custom routes, it is necessary to create the correct annotation in the service account. 
+All the routes to annotate can be listed in the `externalRoutes` field in the custom resource:
+
+```yaml
+  externalRoutes:
+    - second-route
+    - third-route
+```
 ## Deploy
 
 To create the required resources by the operator (e.g. CRD, service account, roles, role binding, deployment, ...), run the following command:

--- a/bundle/manifests/hawt.io_hawtios.yaml
+++ b/bundle/manifests/hawt.io_hawtios.yaml
@@ -175,6 +175,12 @@ spec:
                         type: string
                     type: object
                 type: object
+              externalRoutes:
+                description: List of external route names that will be annotated by
+                  the operator to access the console using the routes
+                items:
+                  type: string
+                type: array
               metadataPropagation:
                 description: The configuration for which metadata on Hawtio custom
                   resources to propagate to generated resources such as deployments,

--- a/deploy/crd/hawtio_v1alpha1_hawtio_crd.yaml
+++ b/deploy/crd/hawtio_v1alpha1_hawtio_crd.yaml
@@ -289,6 +289,12 @@ spec:
                   Note that the operator will recreate the route if the field is emptied,
                   so that the host is re-generated.'
                 type: string
+              externalRoutes:
+                description: List of external route names that will be annotated by
+                  the operator to access the console using the routes
+                items:
+                  type: string
+                type: array
               type:
                 description: 'The deployment type. Defaults to cluster. cluster: Hawtio
                   is capable of discovering and managing applications across all namespaces

--- a/pkg/apis/hawtio/v1alpha1/hawtio_types.go
+++ b/pkg/apis/hawtio/v1alpha1/hawtio_types.go
@@ -68,6 +68,8 @@ type HawtioSpec struct {
 	RouteHostName string `json:"routeHostName,omitempty"`
 	// Custom certificate configuration for the route
 	Route HawtioRoute `json:"route,omitempty"`
+	// List of external route names that will be annotated by the operator to access the console using the routes
+	ExternalRoutes []string `json:"externalRoutes,omitempty"`
 	// The Hawtio console container image version. Defaults to 'latest'.
 	Version string `json:"version,omitempty"`
 	// The authentication configuration

--- a/pkg/controller/hawtio/hawtio_controller.go
+++ b/pkg/controller/hawtio/hawtio_controller.go
@@ -715,7 +715,7 @@ func (r *ReconcileHawtio) reconcileDeployment(hawtio *hawtiov1alpha1.Hawtio,
 	var serviceAccount *corev1.ServiceAccount
 	if hawtio.Spec.Type == hawtiov1alpha1.NamespaceHawtioDeploymentType {
 		// Add service account as OAuth client
-		serviceAccount, err = resources.NewServiceAccountAsOauthClient(hawtio.Name)
+		serviceAccount, err = resources.NewServiceAccountAsOauthClient(hawtio.Name, hawtio.Spec.ExternalRoutes)
 		if err != nil {
 			return false, fmt.Errorf("error UpdateResources : %s", err)
 		}

--- a/pkg/resources/service_account_test.go
+++ b/pkg/resources/service_account_test.go
@@ -1,0 +1,20 @@
+package resources
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAnnotations(t *testing.T) {
+	sa, err := NewServiceAccountAsOauthClient("hawtio-online", []string{"one", "two", "three"})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sa.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.hawtio-online"])
+	assert.NotEmpty(t, sa.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.one"])
+	assert.NotEmpty(t, sa.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.two"])
+	assert.NotEmpty(t, sa.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.three"])
+
+	sa, err = NewServiceAccountAsOauthClient("hawtio-online", []string{})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sa.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.hawtio-online"])
+
+}


### PR DESCRIPTION
This PR adds `externalRoutes` to the CRD. Operator will iterate on the routes list and create annotation for the oauth servcie account so routes can be used. 