### PR TITLE
fix: Moves default image repository to quay.io #65

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20-alpine3.18 AS builder
 
 ARG HAWTIO_ONLINE_VERSION=latest
-ARG HAWTIO_ONLINE_IMAGE_NAME=docker.io/hawtio/hawtio
+ARG HAWTIO_ONLINE_IMAGE_NAME=quay.io/hawtio/online
 
 ENV IMAGE_VERSION_FLAG="-X main.ImageVersion=${HAWTIO_ONLINE_VERSION}"
 ENV IMAGE_REPOSITORY_FLAG="-X main.ImageRepository=${HAWTIO_ONLINE_IMAGE_NAME}"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"runtime"
+
 	"github.com/hawtio/hawtio-operator/pkg/controller/hawtio"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"os"
-	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,6 +40,11 @@ var log = logf.Log.WithName("cmd")
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+}
+
+func printBuildVars(bv util.BuildVariables) {
+	log.Info(fmt.Sprintf("Hawtio Online Image Repository: %s", bv.ImageRepository))
+	log.Info(fmt.Sprintf("Hawtio Online Image Version: %s", bv.ImageVersion))
 }
 
 func main() {
@@ -136,6 +142,9 @@ func operatorRun(namespace string, cfg *rest.Config) error {
 		ClientCertCommonName:                 CertificateCommonName,
 		AdditionalLabels:                     AdditionalLabels,
 	}
+
+	printBuildVars(bv)
+
 	if err := controller.AddToManager(mgr, bv); err != nil {
 		log.Error(err, "")
 		return err

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: hawtio-operator
       containers:
         - name: hawtio-operator
-          image: docker.io/hawtio/operator
+          image: quay.io/hawtio/operator
           ports:
           - containerPort: 8080
             name: metrics

--- a/pkg/resources/container.go
+++ b/pkg/resources/container.go
@@ -58,7 +58,7 @@ func getImageFor(tag string, imageRepository string) string {
 		if imageRepository != "" {
 			repository = imageRepository
 		} else {
-			repository = "docker.io/hawtio/online"
+			repository = "quay.io/hawtio/online"
 		}
 	}
 


### PR DESCRIPTION
* Dockerfile
  * Changes the default value of operand image name arg to quay.io

* cmd/manager/main.go
  * Print the Operand repository and version to help with testing

* deploy/operator.yaml
  * Updates the default image name to quay.io

* Makefile
  * Updates the default image name and version to the correct values for quay.io
  * Since using snapshots, automatically update the word snapshot to the current date timestamp
  * Since suffixes are not valid for bundle CSV, adds OPERATOR_VERSION var that drops the suffix before its timestamped
  * Adds get-image and get-version for testing