### PR TITLE
Fixes made as a result of operator testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ tags
 *.iml
 *.ipr
 *.iws
+
+### bundle index directory for install testing
+index
+index.Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ HAWTIO_ONLINE_VERSION ?= latest
 HAWTIO_ONLINE_IMAGE_NAME ?= quay.io/${ORG}/online
 DEBUG ?= false
 LAST_RELEASED_IMAGE_NAME := hawtio-operator
-LAST_RELEASED_VERSION ?= main
+LAST_RELEASED_VERSION ?= 0.5.0
 
 # Drop suffix for use with bundle and CSV
 OPERATOR_VERSION := $(subst -SNAPSHOT,,$(VERSION))
@@ -86,11 +86,10 @@ image:
 #---
 #
 #@ build
+#== Build and test the operator binary
 #
 #* PARAMETERS:
 #** GOLDFLAGS:                 Add any go-lang ldflags, eg. -X main.ImageVersion=2.0.0-202312061128 will compile in the operand version
-#
-#== Build and test the operator binary
 #
 #---
 build: go-generate compile test

--- a/bundle/bases/hawtio-operator.clusterserviceversion.yaml
+++ b/bundle/bases/hawtio-operator.clusterserviceversion.yaml
@@ -68,4 +68,3 @@ spec:
     type: MultiNamespace
   - supported: false
     type: AllNamespaces
-  replaces: hawtio-operator.v0.5.0

--- a/bundle/bases/hawtio-operator.clusterserviceversion.yaml
+++ b/bundle/bases/hawtio-operator.clusterserviceversion.yaml
@@ -18,6 +18,7 @@ spec:
   provider:
     name: Red Hat
   maturity: alpha
+  minKubeVersion: 1.11.0
   description: |
     Hawtio
     ==============

--- a/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
@@ -28,12 +28,38 @@ metadata:
             },
             "type": "Namespace"
           }
+        },
+        {
+          "apiVersion": "hawt.io/v1alpha1",
+          "kind": "Hawtio",
+          "metadata": {
+            "name": "hawtio-online"
+          },
+          "spec": {
+            "auth": {
+              "clientCertCheckSchedule": "* */12 * * *",
+              "clientCertExpirationPeriod": 24
+            },
+            "replicas": 1,
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "200m",
+                "memory": "32Mi"
+              }
+            },
+            "type": "Namespace",
+            "version": 1.12
+          }
         }
       ]
     capabilities: Seamless Upgrades
     categories: Integration & Delivery
     certified: "false"
-    containerImage: docker.io/hawtio/operator:1.0.0
+    containerImage: quay.io/hawtio/operator:1.0.0
     createdAt: "2023-11-13T16:00:10Z"
     description: Hawtio eases the discovery and management of Java applications deployed
       on OpenShift.
@@ -153,13 +179,19 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: hawtio-operator
-                image: docker.io/hawtio/operator:1.0.0
+                image: quay.io/hawtio/operator:1.0.0
                 imagePullPolicy: Always
                 name: hawtio-operator
                 ports:
                 - containerPort: 8080
                   name: metrics
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 256Mi
+                  requests:
+                    cpu: 250m
+                    memory: 100Mi
               serviceAccountName: hawtio-operator
       permissions:
       - rules:
@@ -267,6 +299,7 @@ spec:
   - email: hawtio@googlegroups.com
     name: The Hawtio team
   maturity: alpha
+  minKubeVersion: 1.11.0
   provider:
     name: Red Hat
   replaces: hawtio-operator.v0.5.0

--- a/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
@@ -302,5 +302,4 @@ spec:
   minKubeVersion: 1.11.0
   provider:
     name: Red Hat
-  replaces: hawtio-operator.v0.5.0
   version: 1.0.0

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,12 +1,13 @@
 about:
-  title: Hawtio Console
-  additionalInfo: The Hawtio console eases the discovery and management of 'hawtio-enabled'
+  title: Hawtio Online Console
+  productInfo: []
+  additionalInfo: The Hawtio Online Console eases the discovery and management of 'hawtio-enabled'
     applications deployed on OpenShift.
+  imgSrc: /online/hawtio-logo.svg
 branding:
-  appName: Hawtio Console
-  appLogoUrl: img/hawtio-logo.svg
-online:
-  consoleLink:
-    text: Hawtio Console
-    section: Hawtio
-    imageRelativePath: /online/img/favicon.ico
+  appName: Hawtio Online Console
+  appLogoUrl: /online/hawtio-logo.svg
+  favicon: /online/favicon.ico
+  showAppName: true
+login:
+  title: Log in with your token

--- a/deploy/app/kustomization.yaml
+++ b/deploy/app/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: hawtio
 
 resources:
-- ../crs/hawtio_v1alpha1_hawtio_cr.yaml
+- ../crs/hawtio_v1_hawtio_cr.yaml

--- a/deploy/crs/hawtio_v1alpha1_hawtio_cr.yaml
+++ b/deploy/crs/hawtio_v1alpha1_hawtio_cr.yaml
@@ -1,0 +1,19 @@
+apiVersion: hawt.io/v1alpha1
+kind: Hawtio
+metadata:
+  name: hawtio-online
+spec:
+  type: Namespace
+  version: 1.12
+  replicas: 1
+  auth:
+    clientCertCheckSchedule: "* */12 * * *"
+    clientCertExpirationPeriod: 24
+
+  resources:
+    limits:
+      cpu: "1"
+      memory: 200Mi
+    requests:
+      cpu: 200m
+      memory: 32Mi

--- a/deploy/crs/kustomization.yaml
+++ b/deploy/crs/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - hawtio_v1_hawtio_cr.yaml
+  - hawtio_v1alpha1_hawtio_cr.yaml

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,3 +33,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "hawtio-operator"
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "250m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/script/build_bundle_index.sh
+++ b/script/build_bundle_index.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+
+check_env_var() {
+  if [ -z "${2}" ]; then
+    echo "Error: ${1} env var not defined"
+    exit 1
+  fi
+}
+
+check_env_var "BUNDLE_INDEX" ${BUNDLE_INDEX}
+check_env_var "INDEX_DIR" ${INDEX_DIR}
+check_env_var "PACKAGE" ${PACKAGE}
+check_env_var "OPM" ${OPM}
+check_env_var "YQ" ${YQ}
+check_env_var "BUNDLE_IMAGE" ${BUNDLE_IMAGE}
+check_env_var "CSV_NAME" ${CSV_NAME}
+check_env_var "CHANNELS" ${CHANNELS}
+
+PACKAGE_YAML=${INDEX_DIR}/${PACKAGE}.yaml
+INDEX_BASE_YAML=${INDEX_DIR}/bundles.yaml
+CHANNELS_YAML="${INDEX_DIR}/${PACKAGE}-channels.yaml"
+
+if ! command -v ${OPM} &> /dev/null
+then
+  echo "Error: opm is not available. Was OPM env var defined correctly: ${OPM}"
+  exit 1
+fi
+
+if [ -n "${CSV_REPLACES}" ] && [ -n "${CSV_SKIPS}" ]; then
+  echo
+  echo "Both CSV_REPLACES and CSV_SKIPS have been specified."
+  while [ -z "${brs}" ]; do
+    read -p "Do you wish to include both (b), ignore 'replaces' (r) or ignore 'skips' (s): " brs
+    case ${brs} in
+        [Bb]* )
+          echo "... including both"
+          echo
+          ;;
+        [Rr]* )
+          echo ".. ignoring 'replaces'"
+          echo
+          CSV_REPLACES=""
+          ;;
+        [Ss]* )
+          echo ".. ignoring 'skips'"
+          echo
+          CSV_SKIPS=""
+          ;;
+        * )
+          echo "Please answer b, r or s."
+          echo
+          ;;
+    esac
+  done
+fi
+
+if [ -f "${INDEX_DIR}.Dockerfile" ]; then
+  rm -f "${INDEX_DIR}.Dockerfile"
+fi
+
+mkdir -p "${INDEX_DIR}"
+
+if [ ! -f ${INDEX_BASE_YAML} ]; then
+  ${OPM} render ${BUNDLE_INDEX} -o yaml > ${INDEX_BASE_YAML}
+  if [ $? != 0 ]; then
+    echo "Error: failed to render the base catalog"
+    exit 1
+  fi
+fi
+
+if [ ! -f ${PACKAGE_YAML} ]; then
+  ${OPM} render --skip-tls -o yaml \
+    ${BUNDLE_IMAGE} > ${PACKAGE_YAML}
+  if [ $? != 0 ]; then
+    echo "Error: failed to render the ${PACKAGE} bundle catalog"
+    exit 1
+  fi
+
+  #
+  # Determine whether to add a package schema or not
+  # Applicable to only brand-new products
+  #
+  RESULT=$(${YQ} eval ". | select(.schema == \"olm.package\" and .name == \"${PACKAGE}\") | .name" ${INDEX_BASE_YAML})
+  if [ "${RESULT}" != "${PACKAGE}" ]; then
+    echo "Cannot find package entry in catalog. Adding package to ${PACKAGE_YAML} ..."
+
+    object="{ \"defaultChannel\": \"latest\", \"name\": \"${PACKAGE}\", \"schema\": \"olm.package\" }"
+    package_file=$(mktemp ${PACKAGE}-package-XXX.yaml)
+    trap 'rm -f ${package_file}' EXIT
+    ${YQ} -n eval "${object}" > ${package_file}
+
+    echo "---" >> ${PACKAGE_YAML}
+    cat ${package_file} >> ${PACKAGE_YAML}
+  fi
+fi
+
+#
+# Extract the package channels
+#
+${YQ} eval ". | select(.package == \"${PACKAGE}\" and .schema == \"olm.channel\")" ${INDEX_BASE_YAML} > ${CHANNELS_YAML}
+if [ $? != 0 ] || [ ! -f "${CHANNELS_YAML}" ]; then
+  echo "ERROR: Failed to extract package entries from bundle catalog"
+  exit 1
+fi
+
+#
+# Filter out the channels in the bundles file
+#
+${YQ} -i eval ". | select(.package != \"${PACKAGE}\" or .schema != \"olm.channel\")" ${INDEX_BASE_YAML}
+if [ $? != 0 ]; then
+  echo "ERROR: Failed to remove package channel entries from bundles catalog"
+  exit 1
+fi
+
+#
+# Split the channels and append/insert the bundle into each one
+#
+IFS=','
+#Read the split words into an array based on comma delimiter
+read -r -a CHANNEL_ARR <<< "${CHANNELS}"
+
+for channel in "${CHANNEL_ARR[@]}";
+do
+  channel_props=$(${YQ} eval ". | select(.name == \"${channel}\")" ${CHANNELS_YAML})
+
+  entry="{ \"name\": \"${CSV_NAME}\""
+  if [ -n "${CSV_REPLACES}" ]; then
+    entry="${entry}, \"replaces\": \"${CSV_REPLACES}\""
+  fi
+  if [ -n "${CSV_SKIPS}" ]; then
+    entry="${entry}, \"skipRange\": \"${CSV_SKIPS}\""
+  fi
+  entry="${entry} }"
+
+  if [ -z "${channel_props}" ]; then
+    #
+    # Append a new channel
+    #
+    echo "Appending channel ${channel} ..."
+    object="{ \"entries\": [${entry}], \"name\": \"${channel}\", \"package\": \"${PACKAGE}\", \"schema\": \"olm.channel\" }"
+
+    channel_file=$(mktemp ${channel}-channel-XXX.yaml)
+    trap 'rm -f ${channel_file}' EXIT
+    ${YQ} -n eval "${object}" > ${channel_file}
+
+    echo "---" >> ${CHANNELS_YAML}
+    cat ${channel_file} >> ${CHANNELS_YAML}
+  else
+    #
+    # Channel already exists so insert entry
+    #
+    echo "Inserting channel ${channel} ..."
+    ${YQ} -i eval "(. | select(.name == \"${channel}\") | .entries) += ${entry}" ${CHANNELS_YAML}
+  fi
+done
+
+echo -n "Validating index ... "
+STATUS=$(${OPM} validate ${INDEX_DIR} 2>&1)
+if [ $? != 0 ]; then
+  echo "Failed"
+  echo "Error: ${STATUS}"
+  exit 1
+else
+  echo "OK"
+fi
+
+echo -n "Generating catalog dockerfile ... "
+STATUS=$(${OPM} generate dockerfile ${INDEX_DIR} 2>&1)
+if [ $? != 0 ]; then
+  echo "Failed"
+  echo "Error: ${STATUS}"
+  exit 1
+else
+  echo "OK"
+fi
+
+echo -n "Building catalog image ... "
+BUNDLE_INDEX_IMAGE="${BUNDLE_IMAGE%:*}-index":"${BUNDLE_IMAGE#*:}"
+STATUS=$(docker build . -f ${INDEX_DIR}.Dockerfile -t ${BUNDLE_INDEX_IMAGE} 2>&1)
+if [ $? != 0 ]; then
+  echo "Failed"
+  echo "Error: ${STATUS}"
+  exit 1
+else
+  echo "OK"
+  echo "Index image ${BUNDLE_INDEX_IMAGE} can be pushed"
+fi


### PR DESCRIPTION
- Adds support for installation testing using a locally created bundle-index image;
- Removes the `replace` property from the constructed bundle since no upstream bundle has yet been released;
- Fixes warnings when validating the bundle
  - Adds v1alpha1 CR example
  - Adds cpu and memory resource limits
  - Adds minimum kube version
- Fixes the version of the CR installed with `make app`;
- Updates operator `config.yaml` with default values used in standalone installs
  - Updates title, additionalInfo, appName to include 'Online'
  - Adds image reference paths
  - Removes now invalid online section properties
  - Adds showAppName property to display app name in title bar
  - Adds login properties in case form config is used
  - Adds mandatory 'productInfo' empty array. This works around bug in [hawtio/react (#715)](https://github.com/hawtio/hawtio-next/issues/715)