### PR TITLE
Provides support for installing on vanilla kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,6 +403,26 @@ endif
 
 #---
 #
+#@ cr
+#
+#== Install the app CR only
+#
+#* PARAMETERS:
+#** NAMESPACE:                 Set the namespace for the resources
+#** DEBUG:                     Print the resources to be applied instead of applying them [ true | false ]
+#
+#---
+cr: kubectl kustomize
+	#@ Can be invoked by a user with namespace privileges (rather than a cluster-admin)
+	$(call set-kvars,$(INSTALL_ROOT)/app)
+ifeq ($(DEBUG), false)
+	$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)/app | kubectl apply -f -
+else
+	$(KUSTOMIZE) build $(KOPTIONS) $(INSTALL_ROOT)/app
+endif
+
+#---
+#
 #@ app
 #
 #== Install the app CR and deploy the operator as a normal user

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -1,0 +1,140 @@
+package capabilities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "k8s.io/client-go/kubernetes"
+
+	"github.com/Masterminds/semver"
+	errs "github.com/pkg/errors"
+)
+
+type ApiServerSpec struct {
+	Version           string // Set to the version of the cluster
+	KubeVersion       string // Set to the kubernetes version of the cluster (different to version if using OpenShift, for example)
+	IsOpenShift4      bool   // Set to true if running on openshift 4
+	IsOpenShift43Plus bool   // Set to true if running openshift 4.3+
+	ImageStreams      bool   // Set to true if the API Server supports imagestreams
+	Routes            bool   // Set to true if the API Server supports routes
+	ConsoleLink       bool   // Set to true if the API Server support the openshift console link API
+}
+
+type RequiredApiSpec struct {
+	routes       string
+	imagestreams string
+	consolelinks string
+}
+
+var RequiredApi = RequiredApiSpec{
+	routes:       "routes.route.openshift.io/v1",
+	imagestreams: "imagestreams.image.openshift.io/v1",
+	consolelinks: "consolelinks.console.openshift.io/v1",
+}
+
+func contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}
+
+func createResourceIndex(apiClient kclient.Interface) ([]string, error) {
+	_, apiResourceLists, err := apiClient.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		return nil, err
+	}
+
+	resIndex := []string{}
+
+	for _, apiResList := range apiResourceLists {
+		for _, apiResource := range apiResList.APIResources {
+			resIndex = append(resIndex, fmt.Sprintf("%s.%s", apiResource.Name, apiResList.GroupVersion))
+		}
+	}
+
+	return resIndex, nil
+}
+
+// APICapabilities For testing the given platform's capabilities
+func APICapabilities(ctx context.Context, apiClient kclient.Interface, configClient configclient.Interface) (*ApiServerSpec, error) {
+	if apiClient == nil {
+		return nil, errors.New("No api client. Cannot determine api capabilities")
+	}
+
+	if configClient == nil {
+		return nil, errors.New("No config client. Cannot determine api capabilities")
+	}
+
+	apiSpec := ApiServerSpec{}
+
+	info, err := apiClient.Discovery().ServerVersion()
+	if err != nil {
+		return nil, errs.Wrap(err, "Failed to discover server version")
+	}
+
+	apiSpec.KubeVersion = info.Major + "." + info.Minor
+
+	resIndex, err := createResourceIndex(apiClient)
+	if err != nil {
+		return nil, errs.Wrap(err, "Failed to create API Resource index")
+	}
+
+	apiSpec.Routes = contains(resIndex, RequiredApi.routes)
+	apiSpec.ImageStreams = contains(resIndex, RequiredApi.imagestreams)
+	apiSpec.ConsoleLink = contains(resIndex, RequiredApi.consolelinks)
+
+	apiSpec.IsOpenShift4 = false
+
+	var clusterVersion *configv1.ClusterVersion
+	if apiSpec.ConsoleLink {
+		//
+		// Update the kubernetes version to the Openshift Version
+		//
+		clusterVersion, err = configClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+		if err == nil {
+			apiSpec.IsOpenShift4 = true
+		} else if !kerrors.IsNotFound(err) {
+			// Some other error rather than not found
+			// If error is not found then treat as not OpenShift
+			return nil, errs.Wrap(err, "Error reading cluster version")
+		}
+	}
+
+	if apiSpec.IsOpenShift4 && clusterVersion != nil {
+		// Let's take the latest version from the history
+		for _, update := range clusterVersion.Status.History {
+			if update.State == configv1.CompletedUpdate {
+				// Obtain the version from the last completed update
+				// Update the api spec version
+				var openShiftSemVer *semver.Version
+				openShiftSemVer, err = semver.NewVersion(update.Version)
+				apiSpec.Version = openShiftSemVer.String()
+
+				// Update whether this is OpenShift 4.3+
+				constraint43, _ := semver.NewConstraint(">= 4.3")
+				apiSpec.IsOpenShift43Plus = constraint43.Check(openShiftSemVer)
+				if err != nil {
+					return nil, errs.Wrap(err, fmt.Sprintf("Error parsing OpenShift cluster semantic version %s", update.Version))
+				}
+				break
+			}
+		}
+	} else {
+		// This is not OpenShift so plain kubernetes or something else
+		apiSpec.IsOpenShift4 = false
+
+		// Update version to kubernetes version
+		apiSpec.Version = apiSpec.KubeVersion
+		apiSpec.IsOpenShift43Plus = false
+	}
+
+	return &apiSpec, nil
+}

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capabilities
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+
+	configv1 "github.com/openshift/api/config/v1"
+	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_ApiCapabilities(t *testing.T) {
+
+	res1 := metav1.APIResourceList{
+		GroupVersion: "image.openshift.io/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "imagestreams"},
+		},
+	}
+	res2 := metav1.APIResourceList{
+		GroupVersion: "route.openshift.io/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "routes"},
+		},
+	}
+	res3 := metav1.APIResourceList{
+		GroupVersion: "oauth.openshift.io/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "oauthclientauthorizations"},
+		},
+	}
+	res3a := metav1.APIResourceList{
+		GroupVersion: "console.openshift.io/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "consolelinks"},
+		},
+	}
+
+	res4 := metav1.APIResourceList{
+		GroupVersion: "something.openshift.io/v1",
+	}
+	res5 := metav1.APIResourceList{
+		GroupVersion: "not.anything.io/v1",
+	}
+	res6 := metav1.APIResourceList{
+		GroupVersion: "something.else.io/v1",
+	}
+
+	startTime, _ := time.Parse(time.RFC3339, "2023-09-18T15:35:39Z")
+
+	clusterVersion := &configv1.ClusterVersion{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterVersion",
+			APIVersion: "config.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: configv1.ClusterID("86c5af53-0a82-4d59-957a-4c5a74caf26d"),
+		},
+		Status: configv1.ClusterVersionStatus{
+			Desired: configv1.Release{
+				Image:   "quay.io/crcont/ocp-release@sha256:4769b0a12fbbd7c2d6846a6bcf69761a1339d39bd96be8d44c122eac032caad1",
+				Version: "4.13.12",
+			},
+			History: []configv1.UpdateHistory{
+				{
+					State:          configv1.CompletedUpdate,
+					StartedTime:    metav1.NewTime(startTime),
+					CompletionTime: nil,
+					Image:          "quay.io/crcont/ocp-release@sha256:4769b0a12fbbd7c2d6846a6bcf69761a1339d39bd96be8d44c122eac032caad1",
+					Verified:       false,
+					Version:        "4.13.12",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		resList   []*metav1.APIResourceList
+		expected  ApiServerSpec
+		osversion *configv1.ClusterVersion
+	}{
+		{
+			"Relevant APIs available for fully true api spec",
+			[]*metav1.APIResourceList{&res1, &res2, &res3, &res3a},
+			ApiServerSpec{
+				Version:           "4.13.12",
+				KubeVersion:       "1.26",
+				IsOpenShift4:      true,
+				IsOpenShift43Plus: true,
+				ImageStreams:      true,
+				Routes:            true,
+				ConsoleLink:       true,
+			},
+			clusterVersion,
+		},
+		{
+			"No relevant resources so expect false",
+			[]*metav1.APIResourceList{&res4, &res5, &res6},
+			ApiServerSpec{
+				Version:           "1.26",
+				KubeVersion:       "1.26",
+				IsOpenShift4:      false,
+				IsOpenShift43Plus: false,
+				ImageStreams:      false,
+				Routes:            false,
+			},
+			nil,
+		},
+		{
+			"No resources so everything false",
+			[]*metav1.APIResourceList{},
+			ApiServerSpec{
+				Version:           "1.26",
+				KubeVersion:       "1.26",
+				IsOpenShift4:      false,
+				IsOpenShift43Plus: false,
+				ImageStreams:      false,
+				Routes:            false,
+			},
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := fakekube.NewSimpleClientset()
+			fd := api.Discovery().(*fakediscovery.FakeDiscovery)
+			fd.Resources = tc.resList
+			fd.FakedServerVersion = &version.Info{
+				Major: "1",
+				Minor: "26",
+			}
+
+			var configObjects []runtime.Object
+			if tc.osversion != nil {
+				configObjects = append(configObjects, tc.osversion)
+			}
+			configClient := fakeconfig.NewSimpleClientset(configObjects...)
+
+			apiSpec, err := APICapabilities(context.TODO(), api, configClient)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if apiSpec == nil {
+				t.Error("Failed to return an api specification")
+			}
+
+			if apiSpec.Version != tc.expected.Version {
+				t.Error("Expected api specification version not expected", "actual", apiSpec.Version, "expected", tc.expected.Version)
+			}
+
+			if apiSpec.KubeVersion != tc.expected.KubeVersion {
+				t.Error("Not Expected kube version", "actual", apiSpec.KubeVersion, "expected", tc.expected.KubeVersion)
+			}
+
+			if apiSpec.IsOpenShift4 != tc.expected.IsOpenShift4 {
+				t.Error("Not Expected cluster to be openshift4", "actual", apiSpec.IsOpenShift4, "expected", tc.expected.IsOpenShift4)
+			}
+
+			if apiSpec.Routes != tc.expected.Routes {
+				t.Error("Expected api specification routes not expected")
+			}
+
+			if apiSpec.ImageStreams != tc.expected.ImageStreams {
+				t.Error("Expected api specification image streams not expected")
+			}
+		})
+	}
+}
+
+func Test_ApiCapabilitiesOpenshift3(t *testing.T) {
+
+	res1 := metav1.APIResourceList{
+		GroupVersion: "image.openshift.io/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "imagestreams"},
+		},
+	}
+
+	testCases := []struct {
+		name     string
+		resList  []*metav1.APIResourceList
+		expected ApiServerSpec
+	}{
+		{
+			"Openshift 3 parse version 1.11",
+			[]*metav1.APIResourceList{&res1},
+			ApiServerSpec{
+				Version:           "1.11",
+				KubeVersion:       "1.11",
+				IsOpenShift4:      false,
+				IsOpenShift43Plus: false,
+				ImageStreams:      true,
+				Routes:            true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := fakekube.NewSimpleClientset()
+			configClient := fakeconfig.NewSimpleClientset()
+			fd := api.Discovery().(*fakediscovery.FakeDiscovery)
+			fd.Resources = tc.resList
+			fd.FakedServerVersion = &version.Info{
+				Major: "1",
+				Minor: "11",
+			}
+
+			apiSpec, err := APICapabilities(context.TODO(), api, configClient)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if apiSpec == nil {
+				t.Error("Failed to return an api specification")
+			}
+
+			if apiSpec.Version != tc.expected.Version {
+				t.Error("Expected api specification version not expected", "Actual", apiSpec.Version, "Expected", tc.expected.Version)
+			}
+
+			if apiSpec.KubeVersion != tc.expected.KubeVersion {
+				t.Error("Not Expected kube version", "actual", apiSpec.KubeVersion, "expected", tc.expected.KubeVersion)
+			}
+
+			if apiSpec.IsOpenShift4 {
+				t.Error("Expected not to be openshift cluster")
+			}
+
+			if apiSpec.ImageStreams != tc.expected.ImageStreams {
+				t.Error("Expected api specification image streams not expected")
+			}
+
+		})
+	}
+}
+
+func Test_ApiCapabilitiesKubernetes(t *testing.T) {
+
+	testCases := []struct {
+		name     string
+		resList  []*metav1.APIResourceList
+		expected ApiServerSpec
+	}{
+		{
+			"Vanilla Kubernetes parse version 1.26",
+			[]*metav1.APIResourceList{},
+			ApiServerSpec{
+				Version:           "1.26",
+				KubeVersion:       "1.26",
+				IsOpenShift4:      false,
+				IsOpenShift43Plus: false,
+				ImageStreams:      false,
+				Routes:            false,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := fakekube.NewSimpleClientset()
+			configClient := fakeconfig.NewSimpleClientset()
+			fd := api.Discovery().(*fakediscovery.FakeDiscovery)
+			fd.Resources = tc.resList
+			fd.FakedServerVersion = &version.Info{
+				Major: "1",
+				Minor: "26",
+			}
+
+			apiSpec, err := APICapabilities(context.TODO(), api, configClient)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if apiSpec == nil {
+				t.Error("Failed to return an api specification")
+			}
+
+			if apiSpec.Version != tc.expected.Version {
+				t.Error("Expected api specification version not expected", "Actual", apiSpec.Version, "Expected", tc.expected.Version)
+			}
+
+			if apiSpec.KubeVersion != tc.expected.KubeVersion {
+				t.Error("Not Expected kube version", "actual", apiSpec.KubeVersion, "expected", tc.expected.KubeVersion)
+			}
+
+			if apiSpec.IsOpenShift4 {
+				t.Error("Expected not to be openshift cluster")
+			}
+
+			if apiSpec.ImageStreams != tc.expected.ImageStreams {
+				t.Error("Expected api specification image streams not expected")
+			}
+
+		})
+	}
+}

--- a/pkg/controller/hawtio/fakeclient_test.go
+++ b/pkg/controller/hawtio/fakeclient_test.go
@@ -8,15 +8,16 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	routev1 "github.com/openshift/api/route/v1"
-
 	fakeconfig "github.com/openshift/client-go/config/clientset/versioned/fake"
 	fakeoauth "github.com/openshift/client-go/oauth/clientset/versioned/fake"
+	networkingv1 "k8s.io/api/networking/v1"
 	discoveryfake "k8s.io/client-go/discovery/fake"
 	fakekube "k8s.io/client-go/kubernetes/fake"
 
@@ -39,6 +40,11 @@ func buildReconcileWithFakeClientWithMocks(objs []runtime.Object, t *testing.T) 
 	}
 
 	err = routev1.Install(scheme)
+	if err != nil {
+		assert.Fail(t, "unable to build scheme")
+	}
+
+	err = networkingv1.AddToScheme(scheme)
 	if err != nil {
 		assert.Fail(t, "unable to build scheme")
 	}

--- a/pkg/controller/hawtio/hawtio_controller.go
+++ b/pkg/controller/hawtio/hawtio_controller.go
@@ -539,6 +539,9 @@ func (r *ReconcileHawtio) Reconcile(ctx context.Context, request reconcile.Reque
 			// And requeue to create a new route in the next reconcile loop
 			return reconcile.Result{Requeue: true}, nil
 		}
+	} else {
+		ingressRouteURL = kresources.GetIngressURL(ingress)
+		hawtioCopy.Status.URL = ingressRouteURL
 	}
 
 	// Reconcile console link in OpenShift console

--- a/pkg/controller/hawtio/hawtio_controller.go
+++ b/pkg/controller/hawtio/hawtio_controller.go
@@ -349,7 +349,7 @@ func (r *ReconcileHawtio) Reconcile(ctx context.Context, request reconcile.Reque
 				if date := hawtio.Spec.Auth.ClientCertExpirationDate; date != nil && !date.IsZero() {
 					expirationDate = date.Time
 				}
-				certSecret, err := generateCertificateSecret(clientSecretName, request.Namespace, caSecret, commonName, expirationDate)
+				certSecret, err := generateCASignedCertSecret(clientSecretName, request.Namespace, caSecret, commonName, expirationDate)
 				if err != nil {
 					reqLogger.Error(err, "Generating the client certificate failed")
 					return reconcile.Result{}, err

--- a/pkg/controller/hawtio/hawtio_controller_kubernetes.go
+++ b/pkg/controller/hawtio/hawtio_controller_kubernetes.go
@@ -1,0 +1,62 @@
+package hawtio
+
+import (
+	"context"
+	"time"
+
+	hawtiov1 "github.com/hawtio/hawtio-operator/pkg/apis/hawtio/v1"
+	errs "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var conKLog = logf.Log.WithName("controller_hawtio_kubernetes")
+
+func kubeCreateServingCertificate(ctx context.Context, r *ReconcileHawtio, hawtio *hawtiov1.Hawtio, name string, namespace string) (*corev1.Secret, error) {
+	// This secret name should be the same as used in deployment.go
+	servingSecretName := hawtio.Name + "-tls-serving"
+
+	// Check whether serving certificate secret exists
+	servingCertSecret, err := r.coreClient.Secrets(namespace).Get(ctx, servingSecretName, metav1.GetOptions{})
+	if err == nil {
+		return servingCertSecret, nil
+	}
+
+	if kerrors.IsNotFound(err) {
+		conKLog.Info("Serving certificate secret not found, creating a new one", "secret", servingSecretName)
+
+		commonName := hawtio.Spec.Auth.ClientCertCommonName
+		if commonName == "" {
+			if r.ClientCertCommonName == "" {
+				commonName = "hawtio-online.hawtio.svc"
+			} else {
+				commonName = r.ClientCertCommonName
+			}
+		}
+		// Let's default to one year validity period
+		expirationDate := time.Now().AddDate(1, 0, 0)
+		if date := hawtio.Spec.Auth.ClientCertExpirationDate; date != nil && !date.IsZero() {
+			expirationDate = date.Time
+		}
+		servingCertSecret, err := generateSelfSignedCertSecret(servingSecretName, namespace, commonName, expirationDate)
+		if err != nil {
+			return nil, errs.Wrap(err, "Generating the serving certificate failed")
+		}
+		err = controllerutil.SetControllerReference(hawtio, servingCertSecret, r.scheme)
+		if err != nil {
+			return nil, err
+		}
+		_, err = r.coreClient.Secrets(namespace).Create(ctx, servingCertSecret, metav1.CreateOptions{})
+		if err != nil {
+			return nil, errs.Wrap(err, "Creating the serving certificate secret failed")
+		}
+
+		conKLog.Info("Serving certificate created successfully", "secret", servingSecretName)
+		return servingCertSecret, nil
+	}
+
+	return nil, err
+}

--- a/pkg/controller/hawtio/hawtio_controller_openshift.go
+++ b/pkg/controller/hawtio/hawtio_controller_openshift.go
@@ -1,0 +1,99 @@
+package hawtio
+
+import (
+	"context"
+	"time"
+
+	hawtiov1 "github.com/hawtio/hawtio-operator/pkg/apis/hawtio/v1"
+	errs "github.com/pkg/errors"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var conOsLog = logf.Log.WithName("controller_hawtio_openshift")
+
+func osCreateClientCertificate(ctx context.Context, r *ReconcileHawtio, hawtio *hawtiov1.Hawtio, name string, namespace string) (*corev1.Secret, error) {
+	// This secret name should be the same as used in deployment.go
+	clientSecretName := hawtio.Name + "-tls-proxying"
+
+	cronJob := &batchv1.CronJob{}
+	cronJobName := name + "-certificate-expiry-check"
+	cronJobErr := r.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: cronJobName}, cronJob)
+
+	// Check whether client certificate secret exists
+	clientCertSecret, err := r.coreClient.Secrets(namespace).Get(ctx, clientSecretName, metav1.GetOptions{})
+	if err == nil {
+		return clientCertSecret, nil
+	}
+
+	if kerrors.IsNotFound(err) {
+		conOsLog.Info("Client certificate secret not found, creating a new one", "secret", clientSecretName)
+
+		caSecret, err := r.coreClient.Secrets("openshift-service-ca").Get(ctx, "signing-key", metav1.GetOptions{})
+		if err != nil {
+			return nil, errs.Wrap(err, "Reading certificate authority signing key failed")
+		}
+
+		commonName := hawtio.Spec.Auth.ClientCertCommonName
+		if commonName == "" {
+			if r.ClientCertCommonName == "" {
+				commonName = "hawtio-online.hawtio.svc"
+			} else {
+				commonName = r.ClientCertCommonName
+			}
+		}
+		// Let's default to one year validity period
+		expirationDate := time.Now().AddDate(1, 0, 0)
+		if date := hawtio.Spec.Auth.ClientCertExpirationDate; date != nil && !date.IsZero() {
+			expirationDate = date.Time
+		}
+		clientCertSecret, err := generateCASignedCertSecret(clientSecretName, namespace, caSecret, commonName, expirationDate)
+		if err != nil {
+			return nil, errs.Wrap(err, "Generating the client certificate failed")
+		}
+		err = controllerutil.SetControllerReference(hawtio, clientCertSecret, r.scheme)
+		if err != nil {
+			return nil, err
+		}
+		_, err = r.coreClient.Secrets(namespace).Create(ctx, clientCertSecret, metav1.CreateOptions{})
+		conOsLog.Info("Client certificate created successfully", "secret", clientSecretName)
+		if err != nil {
+			return nil, errs.Wrap(err, "Creating the client certificate secret failed")
+		}
+
+		// check if certificate rotation is enabled
+		if hawtio.Spec.Auth.ClientCertCheckSchedule != "" {
+			// generate auto-renewal cron job for the secret if it already hasn't been generated.
+			if cronJobErr != nil && kerrors.IsNotFound(cronJobErr) {
+				pod, err := getOperatorPod(ctx, r.client, namespace)
+				if err != nil {
+					return nil, err
+				}
+
+				//create cronJob to validate the Cert
+				cronJob = createCertValidationCronJob(cronJobName, namespace,
+					hawtio.Spec.Auth.ClientCertCheckSchedule, pod.Spec.ServiceAccountName, pod.Spec.Containers[0],
+					hawtio.Spec.Auth.ClientCertExpirationPeriod)
+
+				err = controllerutil.SetControllerReference(hawtio, cronJob, r.scheme)
+				if err != nil {
+					return nil, err
+				}
+				err = r.client.Create(ctx, cronJob)
+
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		return clientCertSecret, nil
+	}
+
+	return nil, err
+}

--- a/pkg/controller/hawtio/hawtio_controller_test.go
+++ b/pkg/controller/hawtio/hawtio_controller_test.go
@@ -160,6 +160,10 @@ func TestHawtioController_Reconcile(t *testing.T) {
 					Name:  resources.HawtioRbacEnvVar,
 					Value: "",
 				},
+				{
+					Name:  resources.HawtioAuthEnvVar,
+					Value: "form",
+				},
 			})
 		})
 	})

--- a/pkg/resources/deployment.go
+++ b/pkg/resources/deployment.go
@@ -44,10 +44,10 @@ func NewDeployment(hawtio *hawtiov1.Hawtio, apiSpec *capabilities.ApiServerSpec,
 
 func newDeployment(hawtio *hawtiov1.Hawtio, replicas *int32, pts corev1.PodTemplateSpec) *appsv1.Deployment {
 	annotations := map[string]string{}
-	propagateAnnotations(hawtio, annotations)
+	PropagateAnnotations(hawtio, annotations)
 
-	labels := labelsForHawtio(hawtio.Name)
-	propagateLabels(hawtio, labels)
+	labels := LabelsForHawtio(hawtio.Name)
+	PropagateLabels(hawtio, labels)
 
 	// Deployment replicas field is defaulted to '1', so we have to equal that defaults, otherwise
 	// the comparison algorithm assumes the requested resource is different, which leads to an infinite
@@ -64,7 +64,7 @@ func newDeployment(hawtio *hawtiov1.Hawtio, replicas *int32, pts corev1.PodTempl
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &r,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labelsForHawtio(hawtio.Name),
+				MatchLabels: LabelsForHawtio(hawtio.Name),
 			},
 			Template: pts,
 			Strategy: appsv1.DeploymentStrategy{
@@ -84,7 +84,7 @@ func newPodTemplateSpec(hawtio *hawtiov1.Hawtio, apiSpec *capabilities.ApiServer
 	if clientCertSecretVersion != "" {
 		annotations[clientCertSecretVersionAnnotation] = clientCertSecretVersion
 	}
-	propagateAnnotations(hawtio, annotations)
+	PropagateAnnotations(hawtio, annotations)
 
 	volumeMounts, err := newVolumeMounts(apiSpec.IsOpenShift4, hawtioVersion, hawtio.Spec.RBAC.ConfigMap, buildVariables)
 	if err != nil {
@@ -95,7 +95,7 @@ func newPodTemplateSpec(hawtio *hawtiov1.Hawtio, apiSpec *capabilities.ApiServer
 	}
 	volumes := newVolumes(hawtio, apiSpec.IsOpenShift4)
 
-	labels := labelsForHawtio(hawtio.Name)
+	labels := LabelsForHawtio(hawtio.Name)
 	additionalLabels, err := labelUtils.ConvertSelectorToLabelsMap(buildVariables.AdditionalLabels)
 	if err != nil {
 		return corev1.PodTemplateSpec{}, err
@@ -103,7 +103,7 @@ func newPodTemplateSpec(hawtio *hawtiov1.Hawtio, apiSpec *capabilities.ApiServer
 	for name, value := range additionalLabels {
 		labels[name] = value
 	}
-	propagateLabels(hawtio, labels)
+	PropagateLabels(hawtio, labels)
 
 	pod := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -151,7 +151,7 @@ func newVolumes(hawtio *hawtiov1.Hawtio, isOpenShift4 bool) []corev1.Volume {
 func newEnvVars(hawtio *hawtiov1.Hawtio, apiSpec *capabilities.ApiServerSpec, openShiftConsoleURL string) []corev1.EnvVar {
 	var envVars []corev1.EnvVar
 
-	envVarsForHawtio := envVarsForHawtio(hawtio.Spec.Type, hawtio.Name)
+	envVarsForHawtio := envVarsForHawtio(hawtio.Spec.Type, hawtio.Name, apiSpec.IsOpenShift4)
 	envVars = append(envVars, envVarsForHawtio...)
 
 	if apiSpec.IsOpenShift4 {

--- a/pkg/resources/kubernetes/ingress.go
+++ b/pkg/resources/kubernetes/ingress.go
@@ -1,0 +1,69 @@
+package kubernetes
+
+import (
+	hawtiov1 "github.com/hawtio/hawtio-operator/pkg/apis/hawtio/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hawtio/hawtio-operator/pkg/resources"
+)
+
+// NewIngress create a new Ingress resource
+func NewIngress(hawtio *hawtiov1.Hawtio, servingSecret *corev1.Secret) *networkingv1.Ingress {
+	name := hawtio.Name
+
+	annotations := map[string]string{}
+	annotations["nginx.ingress.kubernetes.io/backend-protocol"] = "HTTPS"
+	annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "true"
+	annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$1"
+
+	resources.PropagateAnnotations(hawtio, annotations)
+
+	labels := map[string]string{
+		resources.LabelAppKey: "hawtio",
+	}
+	resources.PropagateLabels(hawtio, labels)
+
+	ingressTLS := networkingv1.IngressTLS{}
+	if servingSecret != nil {
+		ingressTLS.SecretName = servingSecret.Name
+	}
+
+	pathPrefix := networkingv1.PathTypePrefix
+
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+			Labels:      labels,
+			Name:        name,
+		},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
+				ingressTLS,
+			},
+			Rules: []networkingv1.IngressRule{
+				{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{{
+								Path:     "/(.*)",
+								PathType: &pathPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: hawtio.Name,
+										Port: networkingv1.ServiceBackendPort{
+											Number: 443,
+										},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return ingress
+}

--- a/pkg/resources/kubernetes/ingress.go
+++ b/pkg/resources/kubernetes/ingress.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"strconv"
+
 	hawtiov1 "github.com/hawtio/hawtio-operator/pkg/apis/hawtio/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -66,4 +68,73 @@ func NewIngress(hawtio *hawtiov1.Hawtio, servingSecret *corev1.Secret) *networki
 	}
 
 	return ingress
+}
+
+// GetIngressURL determines the full URL of the given ingress
+func GetIngressURL(ingress *networkingv1.Ingress) string {
+	var scheme string
+	if len(ingress.Spec.TLS) > 0 {
+		scheme = "https"
+	} else {
+		scheme = "http"
+	}
+
+	host, port := getIngressHostAndPort(ingress)
+	path := getIngressPath(ingress)
+
+	url := scheme + "://" + host
+	if len(port) > 0 {
+		url = url + ":" + port
+	}
+
+	return url + path
+}
+
+func getIngressHostAndPort(ingress *networkingv1.Ingress) (string, string) {
+	ingressStatuses := ingress.Status.LoadBalancer.Ingress
+	if len(ingressStatuses) == 0 {
+		for _, ingressRule := range ingress.Spec.Rules {
+			if len(ingressRule.Host) > 0 {
+				return ingressRule.Host, ""
+			}
+		}
+
+		return "*", "" // host must be a wildcard
+	}
+
+	// get host or ip of the first ingress status available
+	var host string
+	port := ""
+	for _, ingressStatus := range ingress.Status.LoadBalancer.Ingress {
+		if len(ingressStatus.Hostname) > 0 {
+			host = ingressStatus.Hostname
+		} else if len(ingressStatus.IP) > 0 {
+			host = ingressStatus.IP
+		}
+
+		if len(host) > 0 {
+			for _, statusPort := range ingressStatus.Ports {
+				port = strconv.FormatInt(int64(statusPort.Port), 10)
+				continue // get the first port
+			}
+		}
+	}
+
+	if len(host) == 0 {
+		return "*", port
+	}
+
+	return host, port
+}
+
+func getIngressPath(ingress *networkingv1.Ingress) string {
+	for _, ingressRule := range ingress.Spec.Rules {
+		if ingressRule.IngressRuleValue.HTTP != nil {
+			for _, httpPath := range ingressRule.IngressRuleValue.HTTP.Paths {
+				return httpPath.Path
+			}
+		}
+	}
+
+	return "/"
 }

--- a/pkg/resources/kubernetes/ingress_test.go
+++ b/pkg/resources/kubernetes/ingress_test.go
@@ -1,0 +1,73 @@
+package kubernetes
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/hawtio/hawtio-operator/pkg/resources"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIngressURL(t *testing.T) {
+	annotations := map[string]string{}
+	annotations["nginx.ingress.kubernetes.io/backend-protocol"] = "HTTPS"
+	annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"] = "true"
+	annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$1"
+
+	labels := map[string]string{
+		resources.LabelAppKey: "hawtio",
+	}
+	pathPrefix := networkingv1.PathTypePrefix
+	name := "hawtio-online"
+
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+			Labels:      labels,
+			Name:        name,
+		},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
+				{
+					SecretName: "some-tls-secret",
+				},
+			},
+			Rules: []networkingv1.IngressRule{
+				{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{{
+								Path:     "/(.*)",
+								PathType: &pathPrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: name,
+										Port: networkingv1.ServiceBackendPort{
+											Number: 443,
+										},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		Status: networkingv1.IngressStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{
+						IP: "192.168.99.9",
+					},
+				},
+			},
+		},
+	}
+
+	url := GetIngressURL(ingress)
+	assert.Equal(t, "https://192.168.99.9/(.*)", url)
+}

--- a/pkg/resources/label.go
+++ b/pkg/resources/label.go
@@ -6,19 +6,20 @@ import (
 )
 
 const (
-	labelAppKey      = "app"
+	LabelAppKey      = "app"
 	labelResourceKey = "deployment"
 )
 
-// Set labels in a map
-func labelsForHawtio(name string) map[string]string {
+// LabelsForHawtio Set labels in a map
+func LabelsForHawtio(name string) map[string]string {
 	return map[string]string{
-		labelAppKey:      "hawtio",
+		LabelAppKey:      "hawtio",
 		labelResourceKey: name,
 	}
 }
 
-func propagateAnnotations(hawtio *hawtiov1.Hawtio, annotations map[string]string) {
+// PropagateAnnotations propagate annotations from hawtio CR
+func PropagateAnnotations(hawtio *hawtiov1.Hawtio, annotations map[string]string) {
 	for k, v := range hawtio.GetAnnotations() {
 		// Only propagate specified annotations
 		if !util.MatchPatterns(hawtio.Spec.MetadataPropagation.Annotations, k) {
@@ -31,7 +32,8 @@ func propagateAnnotations(hawtio *hawtiov1.Hawtio, annotations map[string]string
 	}
 }
 
-func propagateLabels(hawtio *hawtiov1.Hawtio, labels map[string]string) {
+// PropagateLabels propagate labels from hawtio CR
+func PropagateLabels(hawtio *hawtiov1.Hawtio, labels map[string]string) {
 	for k, v := range hawtio.GetLabels() {
 		// Only propagate specified labels
 		if !util.MatchPatterns(hawtio.Spec.MetadataPropagation.Labels, k) {

--- a/pkg/resources/label_test.go
+++ b/pkg/resources/label_test.go
@@ -35,7 +35,7 @@ func TestPropagateAnnotations(t *testing.T) {
 	annotations := map[string]string{
 		"annotation1": "value0",
 	}
-	propagateAnnotations(hawtio, annotations)
+	PropagateAnnotations(hawtio, annotations)
 	assert.Len(t, annotations, 5)
 	assert.Equal(t, "value0", annotations["annotation1"])
 	assert.Equal(t, "value2", annotations["annotation2"])
@@ -69,7 +69,7 @@ func TestPropagateLabels(t *testing.T) {
 	labels := map[string]string{
 		"label1": "value0",
 	}
-	propagateLabels(hawtio, labels)
+	PropagateLabels(hawtio, labels)
 	assert.Len(t, labels, 5)
 	assert.Equal(t, "value0", labels["label1"])
 	assert.Equal(t, "value2", labels["label2"])

--- a/pkg/resources/openshift/route.go
+++ b/pkg/resources/openshift/route.go
@@ -1,4 +1,4 @@
-package resources
+package openshift
 
 import (
 	"time"
@@ -9,18 +9,20 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 
 	hawtiov1 "github.com/hawtio/hawtio-operator/pkg/apis/hawtio/v1"
+
+	"github.com/hawtio/hawtio-operator/pkg/resources"
 )
 
-func NewRoute(hawtio *hawtiov1.Hawtio, routeTLSSecret, caCertRouteSecret *v1.Secret) *routev1.Route {
+func NewRoute(hawtio *hawtiov1.Hawtio, routeTLSSecret *v1.Secret, caCertRouteSecret *v1.Secret) *routev1.Route {
 	name := hawtio.Name
 
 	annotations := map[string]string{}
-	propagateAnnotations(hawtio, annotations)
+	resources.PropagateAnnotations(hawtio, annotations)
 
 	labels := map[string]string{
-		labelAppKey: "hawtio",
+		resources.LabelAppKey: "hawtio",
 	}
-	propagateLabels(hawtio, labels)
+	resources.PropagateLabels(hawtio, labels)
 
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/service.go
+++ b/pkg/resources/service.go
@@ -14,12 +14,12 @@ func NewService(hawtio *hawtiov1.Hawtio) *corev1.Service {
 	annotations := map[string]string{
 		"service.beta.openshift.io/serving-cert-secret-name": name + "-tls-serving",
 	}
-	propagateAnnotations(hawtio, annotations)
+	PropagateAnnotations(hawtio, annotations)
 
 	labels := map[string]string{
-		labelAppKey: "hawtio",
+		LabelAppKey: "hawtio",
 	}
-	propagateLabels(hawtio, labels)
+	PropagateLabels(hawtio, labels)
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -36,7 +36,7 @@ func NewService(hawtio *hawtiov1.Hawtio) *corev1.Service {
 					TargetPort: intstr.FromString(containerPortName),
 				},
 			},
-			Selector:                 labelsForHawtio(name),
+			Selector:                 LabelsForHawtio(name),
 			SessionAffinity:          "None",
 			PublishNotReadyAddresses: true,
 		},


### PR DESCRIPTION
- Upgrades the deprecated `api/batch/v1beta1` to `api/batch/v1`;
- Formats test results using `gotestfmt`; 
- Provides `capabilities` API for discovering the type of cluster (OpenShift or Kubernetes) based on the existence of installed APIs, also providing the Kubernetes version and/or the OpenShift release version;
- Tidies up function calls by wrapping parameter variables into structs;
- Provides self-signed certificate creation and installation for the `hawtio-online-tls-serving` secret required for k8;
- `cr` and `uninstall` rules for Makefiles;
- Creation of `ingress` for Kubernetes and `route` for OpenShift;

---
**Should be merged / rebased after**
~1. https://github.com/hawtio/hawtio-operator/pull/101~
~2. https://github.com/hawtio/hawtio-operator/pull/102~