### PR TITLE
chore: Removes deprecated api/batch/v1beta1

### DIFF
--- a/pkg/controller/hawtio/certificate.go
+++ b/pkg/controller/hawtio/certificate.go
@@ -8,13 +8,12 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	v1 "k8s.io/api/batch/v1"
-	"k8s.io/api/batch/v1beta1"
 	"math/big"
 	rand2 "math/rand"
 	"strconv"
 	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -107,20 +106,20 @@ func ValidateCertificate(caSecret corev1.Secret, validAtLeastForHours float64) (
 	return false, nil
 }
 
-func createCertValidationCronJob(name, namespace, schedule, serviceAccountName string, container corev1.Container, period int) *v1beta1.CronJob {
+func createCertValidationCronJob(name, namespace, schedule, serviceAccountName string, container corev1.Container, period int) *batchv1.CronJob {
 	if period == 0 {
 		period = 24
 	}
-	cronjob := &v1beta1.CronJob{
+	cronjob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: v1beta1.CronJobSpec{
+		Spec: batchv1.CronJobSpec{
 			Schedule:          schedule,
-			ConcurrencyPolicy: v1beta1.ForbidConcurrent,
-			JobTemplate: v1beta1.JobTemplateSpec{
-				Spec: v1.JobSpec{
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							ServiceAccountName: serviceAccountName,
@@ -151,7 +150,7 @@ func createCertValidationCronJob(name, namespace, schedule, serviceAccountName s
 	return cronjob
 }
 
-func updateExpirationPeriod(cronJob *v1beta1.CronJob, newPeriod int) bool {
+func updateExpirationPeriod(cronJob *batchv1.CronJob, newPeriod int) bool {
 	arguments := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args
 	for i, arg := range arguments {
 		if arg == "--cert-expiration-period" {

--- a/pkg/controller/hawtio/hawtio_controller.go
+++ b/pkg/controller/hawtio/hawtio_controller.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/batch/v1beta1"
 
 	"github.com/Masterminds/semver"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/RHsyseng/operator-utils/pkg/resource/write"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -302,7 +302,7 @@ func (r *ReconcileHawtio) Reconcile(ctx context.Context, request reconcile.Reque
 	}
 
 	if isOpenShift4 {
-		cronJob := &v1beta1.CronJob{}
+		cronJob := &batchv1.CronJob{}
 		cronJobName := request.Name + "-certificate-expiry-check"
 		cronJobErr := r.client.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: cronJobName}, cronJob)
 
@@ -600,7 +600,7 @@ func (r *ReconcileHawtio) Reconcile(ctx context.Context, request reconcile.Reque
 		}
 	}
 	// Reconcile the client certificate cronJob
-	cronJob := &v1beta1.CronJob{}
+	cronJob := &batchv1.CronJob{}
 	cronJobName := request.Name + "-certificate-expiry-check"
 
 	if cronJobErr := r.client.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: cronJobName}, cronJob); cronJobErr == nil {


### PR DESCRIPTION
* Has been replaced with v1 and removed in later version of kubernetes clusters

---

**Should be merged after #101** 