### PR TITLE
HAWNG-418: Fixes handling of ingresses in route-supported clusters

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -62,6 +62,12 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - '*'
+- apiGroups:
   - template.openshift.io
   resources:
   - processedtemplates
@@ -84,4 +90,3 @@ rules:
     - update
     - create
     - delete
-

--- a/pkg/controller/hawtio/hawtio_controller.go
+++ b/pkg/controller/hawtio/hawtio_controller.go
@@ -157,14 +157,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler, routeSupport bool) error {
 		if err != nil {
 			return errs.Wrap(err, "Failed to create watch for Route resource")
 		}
-	}
-
-	err = c.Watch(&source.Kind{Type: &networkingv1.Ingress{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &hawtiov1.Hawtio{},
-	})
-	if err != nil {
-		return errs.Wrap(err, "Failed to create watch for Ingress resource")
+	} else {
+		err = c.Watch(&source.Kind{Type: &networkingv1.Ingress{}}, &handler.EnqueueRequestForOwner{
+			IsController: true,
+			OwnerType:    &hawtiov1.Hawtio{},
+		})
+		if err != nil {
+			return errs.Wrap(err, "Failed to create watch for Ingress resource")
+		}
 	}
 
 	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{


### PR DESCRIPTION
* deploy/role.yaml
  * Gives operator service account permission to deal with ingresses

* hawtio_controller.go
  * Only watch ingresses if routes are not supported since the former would not be installed in a route-supported cluster