### PR TITLE
HAWNG-613: Restores the version property to the operator CRD

### DIFF
--- a/bundle/bases/hawtio-operator.clusterserviceversion.yaml
+++ b/bundle/bases/hawtio-operator.clusterserviceversion.yaml
@@ -2,6 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    olm.skipRange: '>=1.0.0 <1.0.2'
     capabilities: Seamless Upgrades
     categories: Integration & Delivery
     certified: "false"

--- a/bundle/manifests/hawt.io_hawtios.yaml
+++ b/bundle/manifests/hawt.io_hawtios.yaml
@@ -13,6 +13,10 @@ spec:
     kind: Hawtio
     listKind: HawtioList
     plural: hawtios
+    shortNames:
+    - hwt
+    - hio
+    - hawt
     singular: hawtio
   scope: Namespaced
   versions:
@@ -241,7 +245,7 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -253,7 +257,7 @@ spec:
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               route:
@@ -303,6 +307,11 @@ spec:
                 enum:
                 - Cluster
                 - Namespace
+                type: string
+              version:
+                description: 'The Hawtio console container image version. Deprecated:
+                  Remains for legacy purposes in respect of older operators (<1.0.0)
+                  still requiring it for their installs'
                 type: string
             type: object
           status:
@@ -355,10 +364,12 @@ spec:
       jsonPath: .status.URL
       name: URL
       type: string
+    deprecated: true
+    deprecationWarning: v1alpha1.Hawtio is deprecated, please, use v1.Hawtio instead
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Hawtio Console
+        description: Hawtio is the Schema for the Hawtio Console API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -563,7 +574,7 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -575,7 +586,7 @@ spec:
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               route:

--- a/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
@@ -26,7 +26,8 @@ metadata:
                 "memory": "32Mi"
               }
             },
-            "type": "Namespace"
+            "type": "Namespace",
+            "version": "1.12"
           }
         },
         {
@@ -52,7 +53,7 @@ metadata:
               }
             },
             "type": "Namespace",
-            "version": 1.12
+            "version": "1.12"
           }
         }
       ]
@@ -60,9 +61,10 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/hawtio/operator:1.0.2
-    createdAt: "2024-04-04T14:20:31Z"
+    createdAt: "2024-04-05T13:13:52Z"
     description: Hawtio eases the discovery and management of Java applications deployed
       on OpenShift.
+    olm.skipRange: '>=1.0.0 <1.0.2'
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/hawtio/hawtio-operator

--- a/deploy/crd/hawt.io_hawtios.yaml
+++ b/deploy/crd/hawt.io_hawtios.yaml
@@ -15,6 +15,10 @@ spec:
     kind: Hawtio
     listKind: HawtioList
     plural: hawtios
+    shortNames:
+    - hwt
+    - hio
+    - hawt
     singular: hawtio
   scope: Namespaced
   versions:
@@ -243,7 +247,7 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -255,7 +259,7 @@ spec:
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               route:
@@ -305,6 +309,11 @@ spec:
                 enum:
                 - Cluster
                 - Namespace
+                type: string
+              version:
+                description: 'The Hawtio console container image version. Deprecated:
+                  Remains for legacy purposes in respect of older operators (<1.0.0)
+                  still requiring it for their installs'
                 type: string
             type: object
           status:
@@ -357,10 +366,12 @@ spec:
       jsonPath: .status.URL
       name: URL
       type: string
+    deprecated: true
+    deprecationWarning: v1alpha1.Hawtio is deprecated, please, use v1.Hawtio instead
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Hawtio Console
+        description: Hawtio is the Schema for the Hawtio Console API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -565,7 +576,7 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -577,7 +588,7 @@ spec:
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               route:

--- a/deploy/crs/hawtio_v1_hawtio_cr.yaml
+++ b/deploy/crs/hawtio_v1_hawtio_cr.yaml
@@ -4,6 +4,10 @@ metadata:
   name: hawtio-online
 spec:
   type: Namespace
+
+  # Included for backward compatibility - not used in hawtio-online 2.0.0+
+  version: "1.12"
+
   replicas: 1
   auth:
     clientCertCheckSchedule: "* */12 * * *"

--- a/deploy/crs/hawtio_v1alpha1_hawtio_cr.yaml
+++ b/deploy/crs/hawtio_v1alpha1_hawtio_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hawtio-online
 spec:
   type: Namespace
-  version: 1.12
+  version: "1.12"
   replicas: 1
   auth:
     clientCertCheckSchedule: "* */12 * * *"

--- a/pkg/apis/hawtio/v1/hawtio_types.go
+++ b/pkg/apis/hawtio/v1/hawtio_types.go
@@ -26,7 +26,7 @@ const (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=hawtios,scope=Namespaced,shortName=hawt,categories=hawtio
+// +kubebuilder:resource:path=hawtios,scope=Namespaced,shortName=hwt;hio;hawt,categories=hawtio
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
@@ -72,6 +72,10 @@ type HawtioSpec struct {
 	Route HawtioRoute `json:"route,omitempty"`
 	// List of external route names that will be annotated by the operator to access the console using the routes
 	ExternalRoutes []string `json:"externalRoutes,omitempty"`
+	// The Hawtio console container image version.
+	// Deprecated: Remains for legacy purposes in respect of older
+	// operators (<1.0.0) still requiring it for their installs
+	Version string `json:"version,omitempty"`
 	// The authentication configuration
 	Auth HawtioAuth `json:"auth,omitempty"`
 	// The Nginx runtime configuration

--- a/pkg/apis/hawtio/v1alpha1/hawtio_types.go
+++ b/pkg/apis/hawtio/v1alpha1/hawtio_types.go
@@ -24,8 +24,10 @@ const (
 	NamespaceHawtioDeploymentType HawtioDeploymentType = "Namespace"
 )
 
+// +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=hawtios,scope=Namespaced,categories=hawtio
+// +kubebuilder:resource:path=hawtios,scope=Namespaced,shortName=hwt;hio;hawt,categories=hawtio
+// +kubebuilder:deprecatedversion:warning="v1alpha1.Hawtio is deprecated, please, use v1.Hawtio instead"
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Creation phase"
@@ -33,7 +35,7 @@ const (
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="Console phase"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.URL`,description="Console URL"
 
-// Hawtio Console
+// Hawtio is the Schema for the Hawtio Console API.
 type Hawtio struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
* Makefile
  * Adds a CSV_SKIP_RANGE to hide the 1.0.0 - 1.0.1 versions of the operator that contain the problematic CRD
  * Adds support to pre-bundle rule for CSV_SKIP_RANGE
  * Switches to speech marks around sed patterns to stop the < & > operators in the CSV_SKIP_RANGE from acting as shell redirection operators

* .../hawtio-operator.clusterserviceversion.yaml
  * Executing `make bundle` adds the skipRange property to the CSV

* ...hawtio_cr.yaml
  * version property is a string so should be enclosed with speech marks
  * Includes a default version property in v1 version

* v1/hawtio_types.go
  * Restores the version property and adds comment explaining this is only for legacy purposes. This comment is carried through to the Hawtio form shown in the OpenShift console

* v1alpha1/hawtio_types.go
  * Adds the deprecation warning
  * Tidies up some minor comments

* hawtio.io_hawtios.yaml CRD
  * Re-generated CRD with latest changes including insertion of the version property into the v1 schema