### PR TITLE
Adds master burst rate to the crd

### DIFF
--- a/bundle/manifests/hawt.io_hawtios.yaml
+++ b/bundle/manifests/hawt.io_hawtios.yaml
@@ -1030,6 +1030,14 @@ spec:
                     description: The buffer size for reading client request body.
                       Defaults to `256k`.
                     type: string
+                  masterBurstSize:
+                    description: |-
+                      Defines the maximum number of concurrent requests to the master cluster,
+                      allowed to exceed the rate limit immediately. Must be sized to handle the
+                      "thundering herd" of API calls when Hawtio initializes in Cluster Mode
+                      (e.g., loading 1000+ pods across all namespaces).
+                      Defaults to `5000`.
+                    type: string
                   proxyBuffers:
                     description: |-
                       The number and size of the buffers used for reading a response from

--- a/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/hawtio/operator:1.3.0
-    createdAt: "2025-11-21T14:10:36Z"
+    createdAt: "2026-01-19T13:19:22Z"
     description: Hawtio eases the discovery and management of Java applications deployed
       on OpenShift.
     olm.skipRange: '>=1.0.0 <1.0.2'

--- a/deploy/crd/hawt.io_hawtios.yaml
+++ b/deploy/crd/hawt.io_hawtios.yaml
@@ -1030,6 +1030,14 @@ spec:
                     description: The buffer size for reading client request body.
                       Defaults to `256k`.
                     type: string
+                  masterBurstSize:
+                    description: |-
+                      Defines the maximum number of concurrent requests to the master cluster,
+                      allowed to exceed the rate limit immediately. Must be sized to handle the
+                      "thundering herd" of API calls when Hawtio initializes in Cluster Mode
+                      (e.g., loading 1000+ pods across all namespaces).
+                      Defaults to `5000`.
+                    type: string
                   proxyBuffers:
                     description: |-
                       The number and size of the buffers used for reading a response from

--- a/pkg/apis/hawtio/v2/hawtio_types.go
+++ b/pkg/apis/hawtio/v2/hawtio_types.go
@@ -139,6 +139,12 @@ type HawtioNginx struct {
 	// The size of the buffer used for storing the response body of a subrequest.
 	// Defaults to `10m`.
 	SubrequestOutputBufferSize string `json:"subrequestOutputBufferSize,omitempty"`
+	// Defines the maximum number of concurrent requests to the master cluster,
+	// allowed to exceed the rate limit immediately. Must be sized to handle the
+	// "thundering herd" of API calls when Hawtio initializes in Cluster Mode
+	// (e.g., loading 1000+ pods across all namespaces).
+	// Defaults to `5000`.
+	MasterBurstSize string `json:"masterBurstSize,omitempty"`
 }
 
 // The RBAC configuration

--- a/pkg/resources/environment.go
+++ b/pkg/resources/environment.go
@@ -23,6 +23,7 @@ const (
 	NginxClientBodyBufferSize       = "NGINX_CLIENT_BODY_BUFFER_SIZE"
 	NginxProxyBuffers               = "NGINX_PROXY_BUFFERS"
 	NginxSubrequestOutputBufferSize = "NGINX_SUBREQUEST_OUTPUT_BUFFER_SIZE"
+	NginxMasterBurstSizeEnvVar      = "NGINX_MASTER_BURST"
 	HawtioAuthTypeForm              = "form"
 	HawtioAuthTypeOAuth             = "oauth"
 	HawtioSSLKey                    = "HAWTIO_ONLINE_SSL_KEY"
@@ -174,6 +175,12 @@ func envVarsForNginx(nginx hawtiov2.HawtioNginx) []corev1.EnvVar {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  NginxSubrequestOutputBufferSize,
 			Value: nginx.SubrequestOutputBufferSize,
+		})
+	}
+	if nginx.MasterBurstSize != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  NginxMasterBurstSizeEnvVar,
+			Value: nginx.MasterBurstSize,
 		})
 	}
 	return envVars


### PR DESCRIPTION
* Provides capability for specifying the NGINX_MASTER_BURST env var to the hawtio-online deployment

* See https://github.com/hawtio/hawtio-online/issues/272