### PR TITLE
fix: Updates go version 1.25.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ["1.24.6"]
+        go: ["1.25.7"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.23 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 ARG HAWTIO_ONLINE_VERSION=latest
 ARG HAWTIO_ONLINE_IMAGE_NAME=quay.io/hawtio/online

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hawtio/hawtio-operator
 
-go 1.24.6
+go 1.25.7
 
 require sigs.k8s.io/controller-runtime v0.22.4
 


### PR DESCRIPTION
* Fixes CVE-2025-61726 (https://go.dev/issue/77101) (HAWNG-1587)
* Fixes CVE-2025-61729 (https://go.dev/issue/76445) (HAWNG-1588)