### PR TITLE
HAWNG-2011: Implements authentication support for updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,15 @@ spec:
 > The `version` property present in previous versions of the CRD is no longer applicable
 > and any CRs applied to the cluster, containing this property, will have it automatically removed.
 
-### Overriding configuration of `Hawtio-Online`
+### Overriding configuration of `Hawtio-Operator` and `Hawtio-Online`
 Unlike previous versions of the operator, the version of the `Hawtio-Online` operand is now specified during the building of the operator. Therefore, it should be unnecessary to specify this version of the container image. However, should an override be required then it is possible to add extra environment variables to the deployment resource of this operator. Specifically:
 - IMAGE_VERSION: Adding this environment variable will override the version / tag of the `Hawtio-Online` container image, eg. `2.1.0-20240725`;
 - IMAGE_REPOSITORY: Adding this environment variable will override the image name / repository of the `Hawtio-Online` container image, eg. `quay.io/hawtio/online`;
 - GATEWAY_IMAGE_VERSION: Adding this environment variable will override the version / tag of the 'Hawtio-Online-Gateway' container image, eg. `2.1.0-20240725`;
 - GATEWAY_IMAGE_REPOSITORY: Adding this environment variable will override the image name / repository of the `Hawtio-Online-Gateway` container image, eg. `quay.io/hawtio/gateway`.
 - IMAGE_PULL_POLICY: Adding this environment variable will override the default pull policy (Always) of the deployed hawtio-online images. Accepted values are 'Always', 'IfNotPresent' and 'Never'.
+- OPERATOR_LOG_LEVEL: Adding this environment variable will override the level of logging that the operator performs. Current options are either `info` (default) or `debug`.
+- CUSTOM_PULL_SECRET_NAME: The name of a pull secret used by the updater for checking the image registry for new versions of the hawtio-online images.
 
 ## Features
 
@@ -192,6 +194,23 @@ All the routes to annotate can be listed in the `externalRoutes` field in the cu
     - second-route
     - third-route
 ```
+
+### Updating of `hawtio-online` images
+If the operator has already installed a hawtio-online instance and new versions of images are
+published to the same floating tag then the operator is capable of signalling an update to
+that installed version of hawtio-online.
+An updater routine can poll the registry which sourced the hawtio-online images and check
+whether new images are available. If there are new images then the operator's reconciler is
+triggered and the image properties of the hawtio-online deployment are updated. This leads to
+the hawtio-online deployment being restarted and a new instance of the pod is spun-up to
+replace the old one. Should there be no new versions then the updater returns to a quiet state
+until the next scheduled polling is due.
+
+#### Environment Variables
+The updater can be controlled with the following environment variable:
+- UPDATE_POLLING_INTERVAL: specifies the duration between checks for the updater to determine if new hawtio-online images are available for the operator to upgrade to. Values should be in the form of a duration, ie. `6h`, `12h`. The update is disabled with the default value set to `0`.
+- CUSTOM_PULL_SECRET_NAME: in the event that `hawtio-online` images are being pulled from a registry protected by authentication, it is necessary to provide the updater with the necessary credentials. The [pull secret](https://docs.okd.io/4.21/openshift_images/managing_images/using-image-pull-secrets.html) should be created in the operator's installed namespace and its name specified by this environment variable in the operator's deployment resource. The pull secret will then be extracted and the credentials used for authentication by the updater to the image registry. By default, if this environment variable is not provided, the updater will attempt an anonymous and unauthenticated connection to the image registry - this would be sufficient for public registries, eg. quay.io.
+
 ## Deploy
 
 To create the required resources by the operator (e.g. CRD, service account, roles, role binding, deployment, ...), run the following command:

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/hawtio/hawtio-operator/pkg/apis"
@@ -148,6 +150,22 @@ type mgrConfig struct {
 // MgrOption function to populate manager config
 type MgrOption func(*mgrConfig)
 
+// PollerConfig provides config parameters for creation
+// of the RegistryPoller (see createUpdatePoller)
+type PollerConfig struct {
+	Manager         manager.Manager
+	Namespace       string
+	BuildVars       util.BuildVariables
+	PollingInterval time.Duration
+	ExtraOptions    []remote.Option
+}
+
+// customPullSecretNameEnvVar is the constant for env variable CUSTOM_PULL_SECRET_NAME
+// can specify the name of a custom pull secret in the operator's namespace
+// An empty value means the operator will either try and find a global pull secret
+// (only if on OpenShift) or poll the image registry with no authentication.
+const customPullSecretNameEnvVar = "CUSTOM_PULL_SECRET_NAME"
+
 // WithRestConfig allows an external rest config to be defined
 func WithRestConfig(cfg *rest.Config) MgrOption {
 	return func(c *mgrConfig) {
@@ -204,6 +222,7 @@ func WithMetrics(metrics metricserver.Options) MgrOption {
 	}
 }
 
+// WithRegistryTransport allows an external transport for accessing a registry
 func WithRegistryTransport(transport http.RoundTripper) MgrOption {
 	return func(c *mgrConfig) {
 		c.registryTransport = transport
@@ -257,8 +276,10 @@ func New(mgrOptions ...MgrOption) (manager.Manager, error) {
 
 	// mc.metrics can be empty
 
+	ctx := context.Background()
+
 	// Identify cluster capabilities
-	apiSpec, err := capabilities.APICapabilities(context.TODO(), mc.clientTools.ApiClient, mc.clientTools.ConfigClient)
+	apiSpec, err := capabilities.APICapabilities(ctx, mc.clientTools.ApiClient, mc.clientTools.ConfigClient)
 	if err != nil {
 		return nil, errs.Wrap(err, "Cluster API capability discovery failed")
 	}
@@ -298,9 +319,20 @@ func New(mgrOptions ...MgrOption) (manager.Manager, error) {
 	// Polling interval will be set by default but if the user
 	// has explicitly disabled then don't create the poller or channel
 	//
-	updatePoller, updateChannel, err := createUpdatePoller(mgr, mc.buildVariables, mc.updatePollingInterval, extraOptions)
+	cfg := PollerConfig{
+		Manager:         mgr,
+		Namespace:       operatorPod.Namespace,
+		BuildVars:       mc.buildVariables,
+		PollingInterval: mc.updatePollingInterval,
+		ExtraOptions:    extraOptions,
+	}
+
+	updatePoller, updateChannel, err := createUpdatePoller(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("unable to construct update poller: %w", err)
+		// Force the poller and channel to nil to ensure they are disabled.
+		log.Error(err, "Unable to construct update poller. Auto-updates will be disabled.")
+		updatePoller = nil
+		updateChannel = nil
 	}
 
 	// Register the hawtio controller with the manager
@@ -314,10 +346,20 @@ func New(mgrOptions ...MgrOption) (manager.Manager, error) {
 	return mgr, nil
 }
 
-func createUpdatePoller(mgr manager.Manager, bv util.BuildVariables, updatePollingInterval time.Duration, extraOptions []remote.Option) (*updater.RegistryPoller, chan event.GenericEvent, error) {
-	if updatePollingInterval == 0 {
+func createUpdatePoller(ctx context.Context, cfg PollerConfig) (*updater.RegistryPoller, chan event.GenericEvent, error) {
+	if cfg.PollingInterval == 0 {
 		log.Info("Update Poller: Image polling is disabled (interval is 0). Background updater will not be started.")
 		return nil, nil, nil
+	}
+
+	registryCreds, err := discoverRegistryCredentials(ctx, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pollerKeychain, err := parseKeychain(registryCreds)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	//
@@ -327,18 +369,63 @@ func createUpdatePoller(mgr manager.Manager, bv util.BuildVariables, updatePolli
 	updateChannel := make(chan event.GenericEvent)
 
 	poller := &updater.RegistryPoller{
-		Interval:        updatePollingInterval,
-		OnlineImageURL:  bv.ImageRepository + ":" + bv.ImageVersion,
-		GatewayImageURL: bv.GatewayImageRepository + ":" + bv.GatewayImageVersion,
+		Interval:        cfg.PollingInterval,
+		OnlineImageURL:  cfg.BuildVars.ImageRepository + ":" + cfg.BuildVars.ImageVersion,
+		GatewayImageURL: cfg.BuildVars.GatewayImageRepository + ":" + cfg.BuildVars.GatewayImageVersion,
 		Trigger:         updateChannel,
+		AuthKeychain:    pollerKeychain,
 		Logger:          log.WithName("Update Poller"),
-		ExtraOptions:    extraOptions,
+		ExtraOptions:    cfg.ExtraOptions,
 	}
 
-	if err := mgr.Add(poller); err != nil {
+	if err := cfg.Manager.Add(poller); err != nil {
 		log.Error(err, "Update Poller: failed to add registry poller to manager")
 		return nil, nil, err
 	}
 
 	return poller, updateChannel, nil
+}
+
+func discoverRegistryCredentials(ctx context.Context, cfg PollerConfig) ([]byte, error) {
+	secret := &corev1.Secret{}
+
+	// Try the custom secret in the Operator's namespace
+	customSecretName := os.Getenv(customPullSecretNameEnvVar)
+	if customSecretName != "" {
+		err := cfg.Manager.GetAPIReader().Get(ctx, client.ObjectKey{Namespace: cfg.Namespace, Name: customSecretName}, secret)
+		if err != nil {
+			// Fail on all errors as user specified CUSTOM_PULL_SECRET_NAME
+			return nil, fmt.Errorf("CUSTOM_PULL_SECRET_NAME was specified but the secret could not be retained: %w", err)
+		}
+
+		log.V(util.DebugLogLevel).Info("Secret obtained from CUSTOM_PULL_SECRET_NAME")
+
+		dockerConfigJSON, exists := secret.Data[corev1.DockerConfigJsonKey]
+		if !exists {
+			return nil, fmt.Errorf("(CUSTOM_PULL_SECRET_NAME) Secret %s exists but does not contain a %s key; is it a valid docker-registry secret?", customSecretName, corev1.DockerConfigJsonKey)
+		}
+
+		return dockerConfigJSON, nil
+	}
+
+	// Nothing found, proceed anonymously
+	return nil, nil
+}
+
+func parseKeychain(configBytes []byte) (authn.Keychain, error) {
+	// If no secret was found, return an empty keychain that always resolves to Anonymous
+	if len(configBytes) == 0 {
+		return &updater.DockerConfigKeychain{Auths: make(map[string]authn.AuthConfig)}, nil
+	}
+
+	var config struct {
+		Auths map[string]authn.AuthConfig `json:"auths"`
+	}
+
+	if err := json.Unmarshal(configBytes, &config); err != nil {
+		// If JSON parsing fails, return the error
+		return nil, err
+	}
+
+	return &updater.DockerConfigKeychain{Auths: config.Auths}, nil
 }

--- a/pkg/updater/docker_keychain.go
+++ b/pkg/updater/docker_keychain.go
@@ -1,0 +1,31 @@
+package updater
+
+import (
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+// DockerConfigKeychain implements authn.Keychain
+type DockerConfigKeychain struct {
+	Auths map[string]authn.AuthConfig
+}
+
+// Resolve is called automatically by the library when it's about to make a network call
+func (k *DockerConfigKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	registry := target.RegistryStr()
+
+	// Check if there are credentials for this specific registry
+	if authConfig, exists := k.Auths[registry]; exists {
+		return authn.FromConfig(authConfig), nil
+	}
+
+	// Edge-case handling for Docker Hub's weird legacy URL format in config.json
+	if registry == name.DefaultRegistry {
+		if authConfig, exists := k.Auths["https://index.docker.io/v1/"]; exists {
+			return authn.FromConfig(authConfig), nil
+		}
+	}
+
+	// No credentials found for this registry, proceed anonymously
+	return authn.Anonymous, nil
+}

--- a/pkg/updater/poller.go
+++ b/pkg/updater/poller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/hawtio/hawtio-operator/pkg/util"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +21,7 @@ type RegistryPoller struct {
 	Interval        time.Duration
 	OnlineImageURL  string
 	GatewayImageURL string
+	AuthKeychain    authn.Keychain
 	Logger          logr.Logger
 	Trigger         chan event.GenericEvent // bi-directional channel
 	mu              sync.RWMutex
@@ -73,7 +75,7 @@ func (p *RegistryPoller) checkRegistry(ctx context.Context) {
 	p.Logger.V(util.DebugLogLevel).Info("Update Poller: Polling registry for new digests", "online image", p.OnlineImageURL, "gateway image", p.GatewayImageURL)
 
 	// Check Online Image
-	newOnlineDigest, errOnline := GetLatestDigest(ctx, p.OnlineImageURL, p.ExtraOptions...)
+	newOnlineDigest, errOnline := GetLatestDigest(ctx, p.OnlineImageURL, p.AuthKeychain, p.ExtraOptions...)
 	p.Logger.V(util.DebugLogLevel).Info("Update Poller: New Online Digest:", "digest", newOnlineDigest)
 
 	if errOnline != nil {
@@ -85,7 +87,7 @@ func (p *RegistryPoller) checkRegistry(ctx context.Context) {
 	}
 
 	// Check Gateway Image
-	newGatewayDigest, errGateway := GetLatestDigest(ctx, p.GatewayImageURL, p.ExtraOptions...)
+	newGatewayDigest, errGateway := GetLatestDigest(ctx, p.GatewayImageURL, p.AuthKeychain, p.ExtraOptions...)
 	p.Logger.V(util.DebugLogLevel).Info("Update Poller: New Online Gateway Digest:", "digest", newGatewayDigest)
 	if errGateway != nil {
 		p.Logger.Error(errGateway, "Update Poller: Failed to check Gateway image registry. Skipping cycle.")

--- a/pkg/updater/poller_test.go
+++ b/pkg/updater/poller_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr/testr"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -90,11 +91,13 @@ func TestRegistryPoller_ExpectedUpdate(t *testing.T) {
 	}
 
 	triggerChan := make(chan event.GenericEvent, 1) // Buffer of 1 so it doesn't block
+	anonKeyChain := &DockerConfigKeychain{Auths: make(map[string]authn.AuthConfig)}
 
 	poller := &RegistryPoller{
 		Interval:        10 * time.Millisecond, // Run almost instantly
 		OnlineImageURL:  "quay.io/hawtio/online:latest",
 		GatewayImageURL: "quay.io/hawtio/online-gateway:latest",
+		AuthKeychain:    anonKeyChain,
 		Logger: testr.NewWithOptions(t, testr.Options{
 			Verbosity: 1,
 		}),
@@ -150,10 +153,12 @@ func TestRegistryPoller_Idempotency(t *testing.T) {
 	}
 
 	triggerChan := make(chan event.GenericEvent, 1)
+	anonKeyChain := &DockerConfigKeychain{Auths: make(map[string]authn.AuthConfig)}
 	poller := &RegistryPoller{
 		Interval:        10 * time.Millisecond,
 		OnlineImageURL:  "quay.io/hawtio/online:latest",
 		GatewayImageURL: "quay.io/hawtio/online-gateway:latest",
+		AuthKeychain:    anonKeyChain,
 		Trigger:         triggerChan,
 		Logger:          testr.New(t),
 		ExtraOptions:    []remote.Option{remote.WithTransport(mockTransport)},

--- a/pkg/updater/worker.go
+++ b/pkg/updater/worker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
@@ -17,8 +18,7 @@ var ErrRegistryUnavailable = errors.New("registry connection failed or timed out
 
 // GetLatestDigest fetches the latest digest of the image
 // url from the container registry.
-// TODO: Handle authentication using a pullSecrets array
-func GetLatestDigest(ctx context.Context, imageURL string, extraOpts ...remote.Option) (string, error) {
+func GetLatestDigest(ctx context.Context, imageURL string, authKeychain authn.Keychain, extraOpts ...remote.Option) (string, error) {
 	// Parse the image string into a structured reference
 	ref, err := name.ParseReference(imageURL)
 	if err != nil {
@@ -31,6 +31,7 @@ func GetLatestDigest(ctx context.Context, imageURL string, extraOpts ...remote.O
 	// Setup remote options, injecting timeout context
 	options := []remote.Option{
 		remote.WithContext(timeoutCtx),
+		remote.WithAuthFromKeychain(authKeychain),
 	}
 
 	// Append any injected extra options

--- a/pkg/updater/worker_test.go
+++ b/pkg/updater/worker_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
 )
 
 const fetchAttempts = 3
@@ -14,13 +16,14 @@ const fetchAttempts = 3
 func retryGetDigest(imageURL string) (string, error) {
 	var digest string
 	var err error
+	anonKeyChain := &DockerConfigKeychain{Auths: make(map[string]authn.AuthConfig)}
 
 	// Retry up to 3 times
 	for i := 0; i < fetchAttempts; i++ {
 		// Use a generous timeout for CI
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 
-		digest, err = GetLatestDigest(ctx, imageURL)
+		digest, err = GetLatestDigest(ctx, imageURL, anonKeyChain)
 		cancel()
 
 		if err == nil {


### PR DESCRIPTION
* Some image registries are protected with authentication and so pull secrets are necessary for successful connection.

* Implements injection of authentication using either an env var specifying a secret (CUSTOM_PULL_SECRET_NAME) in the operator installed namespace.

* manager.go
  * While creating the polling updater, discovers registry credentials and converts them into an authentication keychain for supply to the updater routine.

* docker_keychain.go
  * Implementation of authn.KeyChain that provides authentication creds for a set of registeries taken from a dockerconfigjson secret

* poller.go
  * Supplies the auth keychain to the worker

* worker.go
  * Adds the keychain to the config options presented to the remote client