### PR TITLE
HAWNG-2013: Adds the backgroundDarkModeImgSsrc to support hawtio config

### DIFF
--- a/bundle/manifests/hawt.io_hawtios.yaml
+++ b/bundle/manifests/hawt.io_hawtios.yaml
@@ -876,6 +876,10 @@ spec:
                           Deprecated: Use Description instead. This field is retained for backwards
                           compatibility but will be removed in a future release.
                         type: string
+                      backgroundDarkModeImgSrc:
+                        description: The background image to display in dark mode
+                          on the About dialog
+                        type: string
                       backgroundImgSrc:
                         description: The background image to display on the About
                           dialog

--- a/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hawtio-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/hawtio/operator:2.0.0
-    createdAt: "2026-05-13T19:54:59Z"
+    createdAt: "2026-05-18T13:03:32Z"
     description: Hawtio eases the discovery and management of Java applications deployed
       on OpenShift.
     olm.skipRange: '>=1.0.0 <2.0.0'

--- a/deploy/crd/hawt.io_hawtios.yaml
+++ b/deploy/crd/hawt.io_hawtios.yaml
@@ -876,6 +876,10 @@ spec:
                           Deprecated: Use Description instead. This field is retained for backwards
                           compatibility but will be removed in a future release.
                         type: string
+                      backgroundDarkModeImgSrc:
+                        description: The background image to display in dark mode
+                          on the About dialog
+                        type: string
                       backgroundImgSrc:
                         description: The background image to display on the About
                           dialog

--- a/pkg/apis/hawtio/v2/hawtio_types.go
+++ b/pkg/apis/hawtio/v2/hawtio_types.go
@@ -249,6 +249,8 @@ type HawtioAbout struct {
 	ImgDarkModeSrc string `json:"imgDarkModeSrc,omitempty"`
 	// The background image to display on the About dialog
 	BackgroundImgSrc string `json:"backgroundImgSrc,omitempty"`
+	// The background image to display in dark mode on the About dialog
+	BackgroundDarkModeImgSrc string `json:"backgroundDarkModeImgSrc,omitempty"`
 }
 
 // The product information displayed in the About page

--- a/pkg/controller/internal/hawtiotest/kubernetes/config/config.yaml
+++ b/pkg/controller/internal/hawtiotest/kubernetes/config/config.yaml
@@ -8,6 +8,7 @@ branding:
   appLogoUrl: img/hawtio-logo.svg
   appLogoDarkModeUrl: img/hawtio-logo.svg
   showAppName: true
+  backgroundImgSrc: img/background.svg
 online:
   consoleLink:
     text: Hawtio Console

--- a/pkg/controller/internal/hawtiotest/kubernetes/testdata/configmap.yml
+++ b/pkg/controller/internal/hawtiotest/kubernetes/testdata/configmap.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  hawtconfig.json: '{"about":{"description":"The Hawtio console eases the discovery and management of hawtio-enabled applications deployed on Kubernetes.","title":"Hawtio Console"},"branding":{"appLogoDarkModeUrl":"img/hawtio-logo.svg","appLogoUrl":"img/hawtio-logo.svg","appName":"Hawtio Console","showAppName":true},"online":{"consoleLink":{"imageRelativePath":"/online/img/favicon.ico","section":"Hawtio","text":"Hawtio Console"}}}'
+  hawtconfig.json: '{"about":{"description":"The Hawtio console eases the discovery and management of hawtio-enabled applications deployed on Kubernetes.","title":"Hawtio Console"},"branding":{"appLogoDarkModeUrl":"img/hawtio-logo.svg","appLogoUrl":"img/hawtio-logo.svg","appName":"Hawtio Console","backgroundImgSrc":"img/background.svg","showAppName":true},"online":{"consoleLink":{"imageRelativePath":"/online/img/favicon.ico","section":"Hawtio","text":"Hawtio Console"}}}'
 kind: ConfigMap
 metadata:
   creationTimestamp: "2025-10-21T09:24:03Z"

--- a/pkg/controller/internal/hawtiotest/openshift/config/config.yaml
+++ b/pkg/controller/internal/hawtiotest/openshift/config/config.yaml
@@ -8,6 +8,7 @@ branding:
   appLogoDarkModeUrl: img/hawtio-logo.svg
   appLogoUrl: img/hawtio-logo.svg
   showAppName: true
+  backgroundImgSrc: img/background.svg
 online:
   consoleLink:
     text: Hawtio Console

--- a/pkg/controller/internal/hawtiotest/openshift/testdata/configmap.yml
+++ b/pkg/controller/internal/hawtiotest/openshift/testdata/configmap.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  hawtconfig.json: '{"about":{"description":"The Hawtio console eases the discovery and management of hawtio-enabled applications deployed on OpenShift.","title":"Hawtio Console"},"branding":{"appLogoDarkModeUrl":"img/hawtio-logo.svg","appLogoUrl":"img/hawtio-logo.svg","appName":"Hawtio Console","showAppName":true},"online":{"consoleLink":{"imageRelativePath":"/online/img/favicon.ico","section":"Hawtio","text":"Hawtio Console"}}}'
+  hawtconfig.json: '{"about":{"description":"The Hawtio console eases the discovery and management of hawtio-enabled applications deployed on OpenShift.","title":"Hawtio Console"},"branding":{"appLogoDarkModeUrl":"img/hawtio-logo.svg","appLogoUrl":"img/hawtio-logo.svg","appName":"Hawtio Console","backgroundImgSrc":"img/background.svg","showAppName":true},"online":{"consoleLink":{"imageRelativePath":"/online/img/favicon.ico","section":"Hawtio","text":"Hawtio Console"}}}'
 kind: ConfigMap
 metadata:
   creationTimestamp: "2025-10-21T09:24:03Z"

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -123,6 +123,15 @@ func configForHawtio(hawtio *hawtiov2.Hawtio, hawtioConfigPath string) (string, 
 		workingConfig.Branding.AppLogoDarkModeURL = workingConfig.Branding.AppLogoURL
 	}
 
+	//
+	// Handle background image if the dark mode image has not been specified
+	//
+	// If a standard background is provided, but no dark mode background exists,
+	// override the upstream UI's default by cloning the standard background.
+	if workingConfig.About.BackgroundImgSrc != "" && workingConfig.About.BackgroundDarkModeImgSrc == "" {
+		workingConfig.About.BackgroundDarkModeImgSrc = workingConfig.About.BackgroundImgSrc
+	}
+
 	data, err = json.Marshal(workingConfig)
 	if err != nil {
 		return "", err

--- a/pkg/resources/configmap_test.go
+++ b/pkg/resources/configmap_test.go
@@ -111,6 +111,24 @@ func TestConfigForHawtio(t *testing.T) {
 			expectErr:    false,
 		},
 		{
+			name: "About Config - Dark mode background should fallback to standard background",
+			hawtio: &hawtiov2.Hawtio{
+				ObjectMeta: metav1.ObjectMeta{Name: "about-hawtio"},
+				Spec: hawtiov2.HawtioSpec{
+					Config: hawtiov2.HawtioConfig{
+						About: hawtiov2.HawtioAbout{
+							Title:            "My Corp Console",
+							BackgroundImgSrc: "https://mycorp.com/background.png",
+							// BackgroundDarkModeImgSrc is intentionally left blank
+						},
+					},
+				},
+			},
+			// Expects the dark mode logo to be automatically populated with the standard logo URL
+			expectedJSON: `{"about": {"title": "Hawtio Console"}, "about": {"title": "My Corp Console",  "backgroundImgSrc": "https://mycorp.com/background.png", "backgroundDarkModeImgSrc": "https://mycorp.com/background.png"}, "branding": {"appName":"Hawtio"}, "online": {"consoleLink": {}}}`,
+			expectErr:    false,
+		},
+		{
 			name: "Branding Config - Dark mode logo should fallback to standard logo",
 			hawtio: &hawtiov2.Hawtio{
 				ObjectMeta: metav1.ObjectMeta{Name: "branding-hawtio"},


### PR DESCRIPTION
* Adds backgroundDarkModeImgSsrc to hawtio API and CRD

* Adds handling of not specifying dark mode background by defaulting to the standard background (if it has been specified)

* Unit tests included